### PR TITLE
fix: fix broken layout caused by html <head> tag

### DIFF
--- a/docs/realm/style/how-to/customize-fonts.md
+++ b/docs/realm/style/how-to/customize-fonts.md
@@ -26,7 +26,7 @@ Adding a font link in the `<head>` element allows the font to download in parall
 This maintains good page performance because the download doesn't block the page's rendering.
 
 <details>
-  <summary>Learn more about the `<head>` tag</summary>
+  <summary>Learn more about the <code>&lt;head&gt;</code> tag</summary>
 
   The `<head>` tag contains metadata, links to
   scripts and stylesheets, and other information that is


### PR DESCRIPTION
## What/Why/How?

The page was broken as <head> can't appear in the middle of the page and markdown formatting can't be used in HTML blocks in md.


## Check yourself

- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
