### PR TITLE
docs: update broken cli links

### DIFF
--- a/blog/communicate-api-changes.md
+++ b/blog/communicate-api-changes.md
@@ -83,7 +83,7 @@ A good addition to the changelog is a friendly email newsletter, showcasing some
 
 ## Learn more
 
-- Add linting to your API, the [struct rule](../docs/cli/rules/oas/struct) requires that the version be set. Remember you'll need to update it yourself.
+- Add linting to your API, the [struct rule](../docs/cli/rules/common/struct) requires that the version be set. Remember you'll need to update it yourself.
 - Adjust your linting standards as you improve your API version-by-version using the [per-API configuration](../docs/cli/configuration/apis).
 - New to API Governance? Read our post about [how to take your first steps in API Governance](./getting-started-api-governance.md).
 

--- a/blog/getting-started-api-governance.md
+++ b/blog/getting-started-api-governance.md
@@ -50,7 +50,7 @@ Instead, start smaller.
 
 ### Minimum Viable API linting
 
-A much better starting point is to enable the [`struct`](../docs/cli/rules/oas/struct) rule only, to simply check that the OpenAPI file is correct.
+A much better starting point is to enable the [`struct`](../docs/cli/rules/common/struct) rule only, to simply check that the OpenAPI file is correct.
 
 To do that, create a file named `redocly.yaml` and add the following content:
 

--- a/blog/redocly-tools-better-openapi-development.md
+++ b/blog/redocly-tools-better-openapi-development.md
@@ -48,7 +48,7 @@ As your OpenAPI description grows in size and complexity, new challenges emerge 
 
 ### Previewing the docs
 
-The ability to [preview](https://redocly.com/docs/cli/commands/preview-docs/) the API reference docs the same way an end-user will experience them is essential. Great docs need to be reviewed for _more_ than just technical correctness. Previewing the API reference docs was especially useful when working with nested schemas and example payloads.
+The ability to [preview](https://redocly.com/docs/cli/commands/preview/) the API reference docs the same way an end-user will experience them is essential. Great docs need to be reviewed for _more_ than just technical correctness. Previewing the API reference docs was especially useful when working with nested schemas and example payloads.
 
 ![Console output from running the "redocly preview docs" command. The output contains a hyperlink to localhost, where the preview is running locally.](images/redocly-tools-better-openapi-development/preview-docs-console.png)
 ![The API reference docs preview for the Museum OpenAPI running on localhost.](images/redocly-tools-better-openapi-development/preview-docs.png )

--- a/docs-legacy/api-reference-docs/guides/on-premise.md
+++ b/docs-legacy/api-reference-docs/guides/on-premise.md
@@ -25,8 +25,8 @@ To work around this issue, you can:
 
 If you want to run the development server, you may do so with the Starter plan or greater as part of our `openapi-cli` tool with the `preview-docs` command (after you `login`). See more information here:
 
-- [`login` command](/docs/cli/commands/login)
-- [`preview-docs` command](/docs/cli/commands/preview-docs)
+- [`login` command](/docs/cli/v1/commands/login)
+- [`preview-docs` command](/docs/cli/v1/commands/preview-docs)
 
 ## On-premise license key
 

--- a/docs-legacy/settings/personal-api-keys.md
+++ b/docs-legacy/settings/personal-api-keys.md
@@ -6,7 +6,7 @@ excludeFromSearch: true
 
 Generate a personal API key to use some of our products:
 
-- The [`@redocly/cli` `login` command](../../docs/cli/commands/login) (where you can subsequently use the [preview-docs](../../docs/cli/commands/preview-docs) or [push](../../docs/cli/commands/push) commands)
+- The [`@redocly/cli` `login` command](../../docs/cli/v1/commands/login) (where you can subsequently use the [preview-docs](../../docs/cli/v1/commands/preview-docs) or [push](../../docs/cli/v1/commands/push) commands)
 - Our [VS Code extension](https://marketplace.visualstudio.com/items?itemName=Redocly.openapi-vs-code)
 - Access-protected API snapshots
 

--- a/docs/respect/commands/index.md
+++ b/docs/respect/commands/index.md
@@ -2,8 +2,8 @@
 
 Redocly CLI commands related to Respect:
 
-* [`generate-arazzo`](/docs/respect/commands/generate-arazzo): Generate an Arazzo file based on an OpenAPI description.
-* [`respect`](/docs/respect/commands/respect): Run tests based on an Arazzo file.
+* [`generate-arazzo`](/docs/cli/commands/generate-arazzo): Generate an Arazzo file based on an OpenAPI description.
+* [`respect`](/docs/cli/commands/respect): Run tests based on an Arazzo file.
 
 ## Resources
 

--- a/docs/respect/get-started.md
+++ b/docs/respect/get-started.md
@@ -99,5 +99,5 @@ You are ready to start trying Respect out yourself or learning more about the to
 
 - [Learn about Arazzo](../../learn/arazzo/what-is-arazzo.md)
 - The official [Arazzo specification](https://spec.openapis.org/arazzo/v1.0.1.html) reference.
-- View the [Respect command reference](/docs/respect/commands/respect) to find out what else you can do.
+- View the [Respect command reference](/docs/cli/commands/respect) to find out what else you can do.
 - Try to edit and expand on the example you created in this guide, creating workflows for your own APIs.

--- a/docs/respect/sidebars.yaml
+++ b/docs/respect/sidebars.yaml
@@ -26,5 +26,5 @@
 - group: Commands
   page: commands/index.md
   items:
-    - page: /docs/respect/commands/generate-arazzo
-    - page: /docs/respect/commands/respect
+    - page: /docs/cli/commands/generate-arazzo
+    - page: /docs/cli/commands/respect

--- a/learn/openapi/multi-file-definitions.md
+++ b/learn/openapi/multi-file-definitions.md
@@ -181,7 +181,7 @@ yarn build
 ### Preview-docs
 
 If you subscribe to our commercial offering, generate an API key under **My profile**, and your previews will be using Redocly API docs (or it will fallback to Redoc community edition).
-Read more about [preview-docs](/docs/cli/commands/preview-docs).
+Read more about [preview-docs](/docs/cli/v1/commands/preview-docs).
 
 {% tabs %}
 {% tab label="npm" %}


### PR DESCRIPTION
## What/Why/How?

Updated broken CLI-related links after making v2 the current version (see the broken links checker).

The docs here should be probably further revised.



## Reference

Related: https://github.com/Redocly/redocly-cli/pull/2222
Original changes: https://github.com/Redocly/redocly-cli/pull/2220



## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
