### PR TITLE
docs: add redirects after releasing CLI v2

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -316,6 +316,14 @@
   to: '/docs/cli/rules/oas/tag-description'
 '/docs/cli/rules/tags-alphabetical':
   to: '/docs/cli/rules/oas/tags-alphabetical'
+'/docs/cli/rules/oas/info-license-url':
+  to: '/docs/cli/rules/oas/info-license-strict'
+'/docs/cli/rules/oas/no-enum-type-mismatch':
+  to: '/docs/cli/rules/common/no-enum-type-mismatch'
+'/docs/cli/rules/oas/no-required-schema-properties-undefined':
+  to: '/docs/cli/rules/common/no-required-schema-properties-undefined'
+'/docs/cli/rules/oas/no-schema-type-mismatch':
+  to: '/docs/cli/rules/common/no-schema-type-mismatch'
 # -- Redirect for renaming redocly-openapi to vscode
 '/docs/redocly-openapi/*':
   to: '/docs/vscode/*'
@@ -348,3 +356,6 @@
   to: '/docs/realm/author/concepts/project-structure'
 '/docs/realm/get-started/api-reference-starter':
   to: '/docs/realm/get-started'
+# -- Redirect to the current changelog after making v2 the default one
+'/docs/cli/v2/changelog':
+  to: '/docs/cli/changelog'


### PR DESCRIPTION
## What/Why/How?

Added redirects after migrating CLI docs to v2.

I mistakingly thought it should be updated [here](https://github.com/Redocly/redocly/pull/16969) but that didn't work. Will revert that PR.

## Reference

Related changes:

https://github.com/Redocly/redocly-cli/pull/2218
https://github.com/Redocly/redocly-cli/pull/2220

Also, found this post from @adamaltman: https://www.linkedin.com/feed/update/urn:li:activity:7354208093796204546?commentUrn=urn%3Ali%3Acomment%3A%28activity%3A7354208093796204546%2C7354208350068236288%29&dashCommentUrn=urn%3Ali%3Afsd_comment%3A%287354208350068236288%2Curn%3Ali%3Aactivity%3A7354208093796204546%29

 
## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
