### PR TITLE
Update redirects.yaml

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -372,6 +372,8 @@
   to: '/docs/realm/reunite/project/ignore-link-checker'
 '/docs/realm/setup/reference/telemetry':
   to: '/docs/realm/reunite/project/telemetry'
+'/docs/realm/setup/reference/reunite-push-action':
+  to: '/docs/realm/reunite/project/remote-content/reunite-push-action'
 # Author how-to redirects
 '/docs/realm/author/how-to/manage-pull-requests':
   to: '/docs/realm/reunite/project/pull-request/manage-pull-requests'


### PR DESCRIPTION
## What/Why/How?
Broken link

## Reference

Reported by our ex-employee (Lesyk)

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/00b7870e-46e5-4c60-8a85-4ba49ab299d2" />

Not sure why link checker doesn't catch it as it's linked from 
![telegram-cloud-photo-size-2-5206637215281707264-y](https://github.com/user-attachments/assets/4a34201e-4ed7-4b5a-bf64-09372cdb3ae8)

cc @volodymyr-rutskyi (could you check link-checkr plz)

## Check yourself

- [x] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
