### PR TITLE
fix: add redirects for cli v1 document links

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -87,7 +87,7 @@
 '/docs/cli/commands/preview-docs/':
   to: '/docs/cli/v1/commands/preview-docs/'
 '/docs/cli/rules/operation-operationId-unique/':
-  to: '/docs/cli/v1/rules/oas/operation-operationId-unique'
+  to: '/docs/cli/v1/rules/oas/operation-operationId-unique/'
 '/docs/cli/rules/oas/struct/':
   to: '/docs/cli/v1/rules/oas/struct/'
 '/docs-legacy/workflows/docs/add-developer-portal/':

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -84,6 +84,12 @@
   to: '/docs/cli/rules/built-in-rules/'
 '/docs/cli/rules/no-empty-enum-servers/':
   to: '/docs/cli/rules/no-server-variables-empty-enum/'
+'/docs/cli/commands/preview-docs/':
+  to: '/docs/cli/v1/commands/preview-docs/'
+'/docs/cli/rules/operation-operationId-unique/':
+  to: '/docs/cli/v1/rules/oas/operation-operationId-unique'
+'/docs/cli/rules/oas/struct/':
+  to: '/docs/cli/v1/rules/oas/struct/'
 '/docs-legacy/workflows/docs/add-developer-portal/':
   to: '/docs-legacy/developer-portal/connect-developer-portal/'
 '/docs-legacy/developer-portal/settings/connect-developer-portal/':


### PR DESCRIPTION
## What/Why/How?

Add redirects for CLIv1 docs broken links:

From:

- https://redocly.com/docs/cli/commands/preview-docs
- https://redocly.com/docs/cli/rules/operation-operationid-unique
- https://redocly.com/docs/cli/rules/oas/struct

TO:

- https://redocly.com/docs/cli/v1/commands/preview-docs
- https://redocly.com/docs/cli/v1/rules/oas/operation-operationId-unique
- https://redocly.com/docs/cli/v1/rules/oas/struct

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
