### PR TITLE
fix: improve memrmaid diagram align

### DIFF
--- a/@theme/styles.css
+++ b/@theme/styles.css
@@ -753,3 +753,11 @@ tr td:first-child code {
     }
     --card-icon-color: red;
 } */
+ 
+.mermaid-wrapper {
+    margin: 1em 0;
+}
+
+.mermaid {
+    text-align: center;
+}


### PR DESCRIPTION
## What/Why/How?

Mermaid diagrams are not centered. Looks very bad and this one of the first pages people land on.

## Screenshots (optional)

**Before**
<img width="1442" height="1058" alt="image" src="https://github.com/user-attachments/assets/a35c0996-8746-4693-82c4-8d2a03f431b3" />


**After**

<img width="1800" height="1066" alt="image" src="https://github.com/user-attachments/assets/0596c340-2a30-4a09-ac64-e198a503d30b" />


## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
