### PR TITLE
chore: exclude legacy docs from search

### DIFF
--- a/docs-legacy/api-reference-docs/changelog.md
+++ b/docs-legacy/api-reference-docs/changelog.md
@@ -1,4 +1,5 @@
 ---
+excludeFromSearch: true
 tocMaxDepth: 2
 ---
 

--- a/docs-legacy/api-reference-docs/configuration/functionality.md
+++ b/docs-legacy/api-reference-docs/configuration/functionality.md
@@ -1,4 +1,5 @@
 ---
+excludeFromSearch: true
 seo:
   title: Configure API docs functionality
 ---

--- a/docs-legacy/api-reference-docs/configuration/theming.md
+++ b/docs-legacy/api-reference-docs/configuration/theming.md
@@ -1,3 +1,7 @@
+---
+excludeFromSearch: true
+---
+
 # Theming options for API docs
 
 {% admonition type="warning" name="Note" %}

--- a/docs-legacy/api-reference-docs/console-config.md
+++ b/docs-legacy/api-reference-docs/console-config.md
@@ -1,4 +1,5 @@
 ---
+excludeFromSearch: true
 seo:
   title: Try-it console configuration
 ---

--- a/docs-legacy/api-reference-docs/console-usage.md
+++ b/docs-legacy/api-reference-docs/console-usage.md
@@ -1,4 +1,5 @@
 ---
+excludeFromSearch: true
 seo:
   title: API Console Usage - Redocly API Reference
 ---

--- a/docs-legacy/api-reference-docs/getting-started.md
+++ b/docs-legacy/api-reference-docs/getting-started.md
@@ -1,4 +1,5 @@
 ---
+excludeFromSearch: true
 seo:
   title: Documentation - Redocly API Reference Docs
 ---

--- a/docs-legacy/api-reference-docs/guides/add-video.md
+++ b/docs-legacy/api-reference-docs/guides/add-video.md
@@ -1,4 +1,5 @@
 ---
+excludeFromSearch: true
 seo:
   title: Add a video to your reference docs
 ---

--- a/docs-legacy/api-reference-docs/guides/embedded-markdown.md
+++ b/docs-legacy/api-reference-docs/guides/embedded-markdown.md
@@ -1,3 +1,7 @@
+---
+excludeFromSearch: true
+---
+
 # Embed Markdown in Redocly API reference docs
 
 Redocly enables you to embed external Markdown file contents into description fields by passing an object to a description with a `$ref` JSON reference.

--- a/docs-legacy/api-reference-docs/guides/generate-code-samples.md
+++ b/docs-legacy/api-reference-docs/guides/generate-code-samples.md
@@ -1,4 +1,5 @@
 ---
+excludeFromSearch: true
 seo:
   title: Generate code samples automatically
 ---

--- a/docs-legacy/api-reference-docs/guides/migration-guide-2-0.md
+++ b/docs-legacy/api-reference-docs/guides/migration-guide-2-0.md
@@ -1,4 +1,5 @@
 ---
+excludeFromSearch: true
 seo:
   title: Redocly Reference docs 2.0 migration guide
 ---

--- a/docs-legacy/api-reference-docs/guides/on-premise-cli-build.md
+++ b/docs-legacy/api-reference-docs/guides/on-premise-cli-build.md
@@ -1,4 +1,5 @@
 ---
+excludeFromSearch: true
 seo:
   title: Use the Reference docs CLI tool
 ---

--- a/docs-legacy/api-reference-docs/guides/on-premise-html-element.md
+++ b/docs-legacy/api-reference-docs/guides/on-premise-html-element.md
@@ -1,4 +1,5 @@
 ---
+excludeFromSearch: true
 seo:
   title: HTML Element Javascript CDN Usage Redocly API Reference
 ---

--- a/docs-legacy/api-reference-docs/guides/on-premise-version-selection.md
+++ b/docs-legacy/api-reference-docs/guides/on-premise-version-selection.md
@@ -1,4 +1,5 @@
 ---
+excludeFromSearch: true
 seo:
   title: Enable the version switcher in on-premise Reference docs
 ---

--- a/docs-legacy/api-reference-docs/guides/on-premise.md
+++ b/docs-legacy/api-reference-docs/guides/on-premise.md
@@ -1,3 +1,7 @@
+---
+excludeFromSearch: true
+---
+
 # On-premise reference docs
 
 If you want to deploy Reference docs on-premise due to specific security constraints, you can use one of these ways:

--- a/docs-legacy/api-reference-docs/guides/try-it-console.md
+++ b/docs-legacy/api-reference-docs/guides/try-it-console.md
@@ -1,4 +1,5 @@
 ---
+excludeFromSearch: true
 seo:
   title: Configure the Try it console
 ---

--- a/docs-legacy/api-reference-docs/guides/use-custom-fonts.md
+++ b/docs-legacy/api-reference-docs/guides/use-custom-fonts.md
@@ -1,4 +1,5 @@
 ---
+excludeFromSearch: true
 seo:
   title: Use custom fonts in your API docs
 ---

--- a/docs-legacy/api-reference-docs/resources/code-samples-languages.md
+++ b/docs-legacy/api-reference-docs/resources/code-samples-languages.md
@@ -1,3 +1,7 @@
+---
+excludeFromSearch: true
+---
+
 ## Supported languages for auto-generated code samples
 
 | Language    | Version          | Notes                                                                                   |

--- a/docs-legacy/api-reference-docs/settings/custom-domain.md
+++ b/docs-legacy/api-reference-docs/settings/custom-domain.md
@@ -1,3 +1,7 @@
+---
+excludeFromSearch: true
+---
+
 # Custom domain
 
 You can edit the subdomain name and configure a custom domain for your API docs on the **Custom domain** page.

--- a/docs-legacy/api-reference-docs/settings/manage-access.md
+++ b/docs-legacy/api-reference-docs/settings/manage-access.md
@@ -1,4 +1,5 @@
 ---
+excludeFromSearch: true
 redirects:
   - '/docs-legacy/workflows/manage-docs-access/': {}
 ---

--- a/docs-legacy/api-reference-docs/spec-extensions.md
+++ b/docs-legacy/api-reference-docs/spec-extensions.md
@@ -1,3 +1,7 @@
+---
+excludeFromSearch: true
+---
+
 # Specification extensions
 
 While the OpenAPI specification tries to accommodate most use cases, additional data can be used to extend the specification and augment its functionality. These additional properties are known as specification extensions (previously called "vendor extensions"). The extension properties are implemented as patterned fields that start with the `x-` naming convention.

--- a/docs-legacy/api-reference-docs/specification-extensions/x-additional-properties-name.md
+++ b/docs-legacy/api-reference-docs/specification-extensions/x-additional-properties-name.md
@@ -1,3 +1,7 @@
+---
+excludeFromSearch: true
+---
+
 # x-additionalPropertiesName
 
 {% admonition type="info" name="Compatibility warning" %}

--- a/docs-legacy/api-reference-docs/specification-extensions/x-code-samples.md
+++ b/docs-legacy/api-reference-docs/specification-extensions/x-code-samples.md
@@ -1,3 +1,7 @@
+---
+excludeFromSearch: true
+---
+
 # x-codeSamples
 
 ## Usage

--- a/docs-legacy/api-reference-docs/specification-extensions/x-default-clientid.md
+++ b/docs-legacy/api-reference-docs/specification-extensions/x-default-clientid.md
@@ -1,3 +1,7 @@
+---
+excludeFromSearch: true
+---
+
 # x-defaultClientId
 
 ## Usage

--- a/docs-legacy/api-reference-docs/specification-extensions/x-display-name.md
+++ b/docs-legacy/api-reference-docs/specification-extensions/x-display-name.md
@@ -1,3 +1,7 @@
+---
+excludeFromSearch: true
+---
+
 # x-displayName
 
 ## Usage

--- a/docs-legacy/api-reference-docs/specification-extensions/x-enum-descriptions.md
+++ b/docs-legacy/api-reference-docs/specification-extensions/x-enum-descriptions.md
@@ -1,3 +1,7 @@
+---
+excludeFromSearch: true
+---
+
 # x-enumDescriptions
 
 {% admonition type="warning" name="Compatibility warning" %}

--- a/docs-legacy/api-reference-docs/specification-extensions/x-examples.md
+++ b/docs-legacy/api-reference-docs/specification-extensions/x-examples.md
@@ -1,3 +1,7 @@
+---
+excludeFromSearch: true
+---
+
 # x-example and x-examples
 
 {% admonition type="info" name="Compatibility warning" %}

--- a/docs-legacy/api-reference-docs/specification-extensions/x-hideTryItPanel.md
+++ b/docs-legacy/api-reference-docs/specification-extensions/x-hideTryItPanel.md
@@ -1,3 +1,7 @@
+---
+excludeFromSearch: true
+---
+
 # x-hideTryItPanel
 
 ## Usage

--- a/docs-legacy/api-reference-docs/specification-extensions/x-logo.md
+++ b/docs-legacy/api-reference-docs/specification-extensions/x-logo.md
@@ -1,3 +1,7 @@
+---
+excludeFromSearch: true
+---
+
 # x-logo
 
 ## Usage

--- a/docs-legacy/api-reference-docs/specification-extensions/x-meta.md
+++ b/docs-legacy/api-reference-docs/specification-extensions/x-meta.md
@@ -1,3 +1,7 @@
+---
+excludeFromSearch: true
+---
+
 # x-meta
 
 {% admonition type="info" name="Important" %}

--- a/docs-legacy/api-reference-docs/specification-extensions/x-nullable.md
+++ b/docs-legacy/api-reference-docs/specification-extensions/x-nullable.md
@@ -1,3 +1,7 @@
+---
+excludeFromSearch: true
+---
+
 # x-nullable
 
 {% admonition type="info" name="Compatibility warning" %}

--- a/docs-legacy/api-reference-docs/specification-extensions/x-servers.md
+++ b/docs-legacy/api-reference-docs/specification-extensions/x-servers.md
@@ -1,3 +1,7 @@
+---
+excludeFromSearch: true
+---
+
 # x-servers
 
 {% admonition type="info" name="Compatibility warning" %}

--- a/docs-legacy/api-reference-docs/specification-extensions/x-summary.md
+++ b/docs-legacy/api-reference-docs/specification-extensions/x-summary.md
@@ -1,3 +1,7 @@
+---
+excludeFromSearch: true
+---
+
 # x-summary
 
 ## Usage

--- a/docs-legacy/api-reference-docs/specification-extensions/x-tag-groups.md
+++ b/docs-legacy/api-reference-docs/specification-extensions/x-tag-groups.md
@@ -1,3 +1,7 @@
+---
+excludeFromSearch: true
+---
+
 # x-tagGroups
 
 ## Usage

--- a/docs-legacy/api-reference-docs/specification-extensions/x-tags.md
+++ b/docs-legacy/api-reference-docs/specification-extensions/x-tags.md
@@ -1,3 +1,7 @@
+---
+excludeFromSearch: true
+---
+
 # x-tags
 
 ## Usage

--- a/docs-legacy/api-reference-docs/specification-extensions/x-trait-tag.md
+++ b/docs-legacy/api-reference-docs/specification-extensions/x-trait-tag.md
@@ -1,3 +1,7 @@
+---
+excludeFromSearch: true
+---
+
 # x-traitTag
 
 ## Usage

--- a/docs-legacy/api-reference-docs/specification-extensions/x-use-pkce.md
+++ b/docs-legacy/api-reference-docs/specification-extensions/x-use-pkce.md
@@ -1,3 +1,7 @@
+---
+excludeFromSearch: true
+---
+
 # x-usePkce
 
 {% admonition type="warning" name="Compatibility warning" %}

--- a/docs-legacy/api-reference-docs/specification-extensions/x-webhooks.md
+++ b/docs-legacy/api-reference-docs/specification-extensions/x-webhooks.md
@@ -1,3 +1,7 @@
+---
+excludeFromSearch: true
+---
+
 # x-webhooks
 
 {% admonition type="warning" name="Compatibility warning" %}

--- a/docs-legacy/api-registry/guides/add-registry-assets.md
+++ b/docs-legacy/api-registry/guides/add-registry-assets.md
@@ -1,3 +1,7 @@
+---
+excludeFromSearch: true
+---
+
 # Add files to your API registry
 
 The API registry serves as a single source of truth for your APIs, and allows you to reuse API definitions across your API versions, docs, and Developer portals.

--- a/docs-legacy/api-registry/guides/api-registry-quickstart.md
+++ b/docs-legacy/api-registry/guides/api-registry-quickstart.md
@@ -1,3 +1,7 @@
+---
+excludeFromSearch: true
+---
+
 # Redocly API registry quickstart
 
 {% admonition type="warning" name="About this quickstart" %}

--- a/docs-legacy/api-registry/guides/edit-registry-files.md
+++ b/docs-legacy/api-registry/guides/edit-registry-files.md
@@ -1,3 +1,7 @@
+---
+excludeFromSearch: true
+---
+
 # Edit files
 
 After [adding your files](./add-registry-assets.md) to the API registry, you can modify their contents.

--- a/docs-legacy/api-registry/guides/index.md
+++ b/docs-legacy/api-registry/guides/index.md
@@ -1,4 +1,5 @@
 ---
+excludeFromSearch: true
 seo:
   title: API registry guides
   description: Learn about the API registry.

--- a/docs-legacy/api-registry/guides/manage-versions.md
+++ b/docs-legacy/api-registry/guides/manage-versions.md
@@ -1,3 +1,7 @@
+---
+excludeFromSearch: true
+---
+
 # Manage API versions
 
 ## Add a version

--- a/docs-legacy/api-registry/guides/migration-guide-config-file.md
+++ b/docs-legacy/api-registry/guides/migration-guide-config-file.md
@@ -1,3 +1,7 @@
+---
+excludeFromSearch: true
+---
+
 # Migration guide: Redocly configuration file
 
 The Redocly configuration file is used by multiple Redocly apps to help you control their behavior.

--- a/docs-legacy/api-registry/guides/mock-server-quickstart.md
+++ b/docs-legacy/api-registry/guides/mock-server-quickstart.md
@@ -1,3 +1,7 @@
+---
+excludeFromSearch: true
+---
+
 # Mock server guide
 
 {% admonition type="info" name="About this feature" %}

--- a/docs-legacy/api-registry/guides/restart-preview-branch-builds.md
+++ b/docs-legacy/api-registry/guides/restart-preview-branch-builds.md
@@ -1,3 +1,7 @@
+---
+excludeFromSearch: true
+---
+
 # Restart preview branch builds
 
 Follow this guide when you need to restart API registry preview branch builds to apply new configuration settings.

--- a/docs-legacy/api-registry/guides/snapshots.md
+++ b/docs-legacy/api-registry/guides/snapshots.md
@@ -1,4 +1,5 @@
 ---
+excludeFromSearch: true
 seo:
   title: Snapshots
 ---

--- a/docs-legacy/api-registry/guides/view-download-assets.md
+++ b/docs-legacy/api-registry/guides/view-download-assets.md
@@ -1,3 +1,7 @@
+---
+excludeFromSearch: true
+---
+
 # Manage files
 
 After adding files to the API registry, you and your collaborators can preview files or download them to the local storage from your browser.

--- a/docs-legacy/api-registry/index.md
+++ b/docs-legacy/api-registry/index.md
@@ -1,4 +1,5 @@
 ---
+excludeFromSearch: true
 exclude: true
 content:
   heroImg: ref-docs-hero

--- a/docs-legacy/api-registry/overview.md
+++ b/docs-legacy/api-registry/overview.md
@@ -1,4 +1,5 @@
 ---
+excludeFromSearch: true
 seo:
   title: Understanding the API registry basics
 ---

--- a/docs-legacy/api-registry/resources/discovering-apis.md
+++ b/docs-legacy/api-registry/resources/discovering-apis.md
@@ -1,3 +1,7 @@
+---
+excludeFromSearch: true
+---
+
 # How to discover APIs in the registry
 
 The API registry serves as a single-source of truth for your APIs. You can use the API registry to store your API definitions and manage multiple versions of each API.

--- a/docs-legacy/api-registry/resources/index.md
+++ b/docs-legacy/api-registry/resources/index.md
@@ -1,4 +1,5 @@
 ---
+excludeFromSearch: true
 seo:
   title: API registry essentials
   description: Basic concepts of the API registry

--- a/docs-legacy/api-registry/resources/versioning-strategies.md
+++ b/docs-legacy/api-registry/resources/versioning-strategies.md
@@ -1,4 +1,5 @@
 ---
+excludeFromSearch: true
 seo:
   title: Versioning strategies
 ---

--- a/docs-legacy/api-registry/settings/api-info.md
+++ b/docs-legacy/api-registry/settings/api-info.md
@@ -1,3 +1,7 @@
+---
+excludeFromSearch: true
+---
+
 # API info
 
 You can edit an API name and version using the API info page. The name/version is used to identify the API in the API registry in Workflows. It does not affect the name and version in your API definition files.

--- a/docs-legacy/api-registry/settings/branches.md
+++ b/docs-legacy/api-registry/settings/branches.md
@@ -1,3 +1,7 @@
+---
+excludeFromSearch: true
+---
+
 # Manage branches
 
 An API version can have one or more branches. Apart from the primary branch, which is mandatory, you can have other active branches (preview branches) associated with the API version.

--- a/docs-legacy/api-registry/settings/delete-version.md
+++ b/docs-legacy/api-registry/settings/delete-version.md
@@ -1,4 +1,5 @@
 ---
+excludeFromSearch: true
 seo:
   title: Delete API version
 ---

--- a/docs-legacy/api-registry/settings/environment-variables.md
+++ b/docs-legacy/api-registry/settings/environment-variables.md
@@ -1,3 +1,7 @@
+---
+excludeFromSearch: true
+---
+
 # Environment variables
 
 Redocly sets environment variables when running API registry jobs. The API registry runs both the `lint` and `bundle` commands which can use environment variables.

--- a/docs-legacy/api-registry/settings/features.md
+++ b/docs-legacy/api-registry/settings/features.md
@@ -1,3 +1,7 @@
+---
+excludeFromSearch: true
+---
+
 # Features
 
 Redocly automatically builds API documentation for all API versions in the registry.

--- a/docs-legacy/api-registry/settings/index.md
+++ b/docs-legacy/api-registry/settings/index.md
@@ -1,4 +1,5 @@
 ---
+excludeFromSearch: true
 seo:
   title: API registry settings
   description: Manage your settings.

--- a/docs-legacy/api-registry/settings/manage-access.md
+++ b/docs-legacy/api-registry/settings/manage-access.md
@@ -1,3 +1,7 @@
+---
+excludeFromSearch: true
+---
+
 # Manage access
 
 Depending on your plan (and [role](../../people/roles-permissions.md), people with the `Owner` role (at the organization level) or `Admin` role (at the project level) can control access to API registry versions.

--- a/docs-legacy/api-registry/settings/mock-servers.md
+++ b/docs-legacy/api-registry/settings/mock-servers.md
@@ -1,3 +1,7 @@
+---
+excludeFromSearch: true
+---
+
 # Mock servers
 
 {% admonition type="info" name="About this feature" %}

--- a/docs-legacy/api-registry/settings/template.md
+++ b/docs-legacy/api-registry/settings/template.md
@@ -1,3 +1,7 @@
+---
+excludeFromSearch: true
+---
+
 # Template
 
 When generating API documentation from your OpenAPI definitions, Redocly uses the default HTML template for all API versions across all Workflows organizations.


### PR DESCRIPTION
## What/Why/How?

Exclude legacy docs from search to reduce any confusion from users when they search for topics (99% of confusion comes from new users who use non-legacy products).

## Reference

- (internal discussion)

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
