### PR TITLE
fix: bug with gap between navbar label and dropdown

### DIFF
--- a/@theme/components/Navbar/NavbarItem.tsx
+++ b/@theme/components/Navbar/NavbarItem.tsx
@@ -467,7 +467,7 @@ const ArrowIcon = styled.svg`
 `;
 
 const NavbarMenuItemDropdown = styled(Dropdown)`
-  height: 32px;
+  height: 10qpx;
 
   li {
     padding: 5px 10px 5px 12px;


### PR DESCRIPTION
## What/Why/How?
When selecting the drop down menu in the top nav, the space between the top nav button and the actual expanded panel has a gap and if the cursor is registered there it closes the menu.

## Reference

## Testing

## Screenshots (optional)
https://github.com/user-attachments/assets/ddc06e55-ae30-40ae-8701-f329f4369343
## Check yourself

- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
