### PR TITLE
chore(deps): fix axios vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@redocly/marketing-pages": "^0.1.16",
-        "@redocly/realm": "0.125.1",
+        "@redocly/realm": "0.125.3",
         "highlight-words-core": "^1.2.3",
         "polished": "^4.3.1"
       },
@@ -596,9 +596,9 @@
       }
     },
     "node_modules/@codemirror/lang-html": {
-      "version": "6.4.9",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.9.tgz",
-      "integrity": "sha512-aQv37pIMSlueybId/2PVSP6NPnmurFDVmZwzc7jszd2KAF8qd4VBbvNYPXWQq90WIARjsdVkPbw29pszmHws3Q==",
+      "version": "6.4.10",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.10.tgz",
+      "integrity": "sha512-h/SceTVsN5r+WE+TVP2g3KDvNoSzbSrtZXCKo4vkKdbfT5t4otuVgngGdFukOO/rwRD2++pCxoh6xD4TEVMkQA==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
@@ -1944,9 +1944,9 @@
       }
     },
     "node_modules/@lezer/javascript": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.3.tgz",
-      "integrity": "sha512-jexmlKq5NpGiB7t+0QkyhSXRgaiab5YisHIQW9C7EcU19KSUsDguZe9WY+rmRDg34nXoNH2LQ4SxpC+aJUchSQ==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.4.tgz",
+      "integrity": "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==",
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.2.0",
@@ -3094,15 +3094,15 @@
       }
     },
     "node_modules/@redocly/asyncapi-docs": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@redocly/asyncapi-docs/-/asyncapi-docs-1.2.0.tgz",
-      "integrity": "sha512-/hmPfqTZQdxq7ocV0iJVc+EpSAshgsCauv+l6fU+AhLFD86tFjc710YPgZjDyIuV/tx6tdT17nvMMJEutbEm1w==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@redocly/asyncapi-docs/-/asyncapi-docs-1.2.1.tgz",
+      "integrity": "sha512-yeu+KFHO8IC8MY9IhydTcngXj3W35n+yjFtnyHJYK92eY/WJ8BYXGJHrK86HHk1C5bo91rNqDaNBrpxJ8UwSVg==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@markdoc/markdoc": "0.5.2",
         "@redocly/config": "0.29.0",
-        "@redocly/openapi-docs": "3.13.0",
-        "@redocly/theme": "0.57.0",
+        "@redocly/openapi-docs": "3.13.1",
+        "@redocly/theme": "0.57.1",
         "jotai": "^2.11.1",
         "openapi-sampler": "^1.6.1",
         "react-router-dom": "^6.21.1",
@@ -3327,15 +3327,15 @@
       "license": "MIT"
     },
     "node_modules/@redocly/openapi-docs": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-docs/-/openapi-docs-3.13.0.tgz",
-      "integrity": "sha512-7CskZizeoS7KQViAqzYLhaSckc3miU0w9dKXkPj3AVWAAPvDM5G0VE8AYyvrb6S8lBc5xAtWORLrE7fK2R7zjA==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-docs/-/openapi-docs-3.13.1.tgz",
+      "integrity": "sha512-U+5oNeuN/mJf1Jo9uVDVil4o0P4IYV0A0yU1H93hPnxJR+73m2Jwj0DGrNvcrwun1A9LeEEw+9QndhJa4yB8Mg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@markdoc/markdoc": "0.5.2",
         "@redocly/config": "0.29.0",
         "@redocly/openapi-core": "2.0.7",
-        "@redocly/replay": "0.16.0",
+        "@redocly/replay": "0.16.1",
         "deepmerge": "^4.2.2",
         "dompurify": "3.2.6",
         "fast-deep-equal": "^3.1.3",
@@ -3376,20 +3376,20 @@
       }
     },
     "node_modules/@redocly/portal-plugin-mock-server": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@redocly/portal-plugin-mock-server/-/portal-plugin-mock-server-0.10.0.tgz",
-      "integrity": "sha512-xYZdWq6rwIGief97PAS5+ytgWGmBZbDkXiIbfquao3pylZAYRlakG0jqS9tSSWJqq1sD0EKI4l8jQcYkL5jsUQ==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@redocly/portal-plugin-mock-server/-/portal-plugin-mock-server-0.10.1.tgz",
+      "integrity": "sha512-8AFiICdO7k/cuaqLjL67ZI3GmEpEhpgm+JYPyVWbrBKB/ZkeM54Da7WS2C23s1OUhI4wlIBYLvZGFILZUgTUGw==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@redocly/config": "0.29.0",
         "@redocly/mock-server": "0.3.4",
-        "@redocly/openapi-docs": "3.13.0"
+        "@redocly/openapi-docs": "3.13.1"
       }
     },
     "node_modules/@redocly/realm": {
-      "version": "0.125.1",
-      "resolved": "https://registry.npmjs.org/@redocly/realm/-/realm-0.125.1.tgz",
-      "integrity": "sha512-ehTyy8bShHB9tqdi+TyioQCaTgKaan3gZluL0OQm6p2Ut4U8akQCCcmBZ5H3BPKELS+ANnOK6rTw6g5yczltyg==",
+      "version": "0.125.3",
+      "resolved": "https://registry.npmjs.org/@redocly/realm/-/realm-0.125.3.tgz",
+      "integrity": "sha512-OrZg+OH8+yXLj1001morVEgAMbh6hxCZRGjBvdKV4c6pAW3/G4KuErDWBCgxm0PoQn4voSefiZn6uX+99BV6Ng==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@babel/core": "7.23.5",
@@ -3410,15 +3410,15 @@
         "@opentelemetry/sdk-trace-web": "2.0.1",
         "@opentelemetry/semantic-conventions": "1.34.0",
         "@redocly/ajv": "8.11.3",
-        "@redocly/asyncapi-docs": "1.2.0",
+        "@redocly/asyncapi-docs": "1.2.1",
         "@redocly/config": "0.29.0",
         "@redocly/graphql-docs": "1.2.0",
         "@redocly/openapi-core": "2.0.7",
-        "@redocly/openapi-docs": "3.13.0",
+        "@redocly/openapi-docs": "3.13.1",
         "@redocly/portal-legacy-ui": "0.8.0",
-        "@redocly/portal-plugin-mock-server": "0.10.0",
-        "@redocly/realm-asyncapi-sdk": "0.3.0",
-        "@redocly/theme": "0.57.0",
+        "@redocly/portal-plugin-mock-server": "0.10.1",
+        "@redocly/realm-asyncapi-sdk": "0.4.0",
+        "@redocly/theme": "0.57.1",
         "@shikijs/transformers": "^1.22.2",
         "@tanstack/react-query": "5.62.3",
         "@tanstack/react-table": "8.21.3",
@@ -3491,15 +3491,15 @@
       }
     },
     "node_modules/@redocly/realm-asyncapi-sdk": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@redocly/realm-asyncapi-sdk/-/realm-asyncapi-sdk-0.3.0.tgz",
-      "integrity": "sha512-z7EjNOVJ+WgcQ6F2n6aGjiOkfvjB/iszMyUNezFan0m1kY04xeSos6lVyifUuYH8FDznTuqaq/KVPitoCt3V5Q==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@redocly/realm-asyncapi-sdk/-/realm-asyncapi-sdk-0.4.0.tgz",
+      "integrity": "sha512-QSl/czxYpWsZfKNJ1ItI242My3AOn8r2kz/TfUHjgF9ayTjCPk4swhhyXrouH4SbmYHaybz40fhC2opSjwFc6Q==",
       "license": "SEE LICENSE IN LICENSE"
     },
     "node_modules/@redocly/replay": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@redocly/replay/-/replay-0.16.0.tgz",
-      "integrity": "sha512-2b6U7t7aJ+ElQ+MJidtP70cSPq++MocbOzQ7HD9SU+7b35nsoPuAo0TBEkyAIBSAyCs4+uF0QHeJk9Ql0+PxqQ==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@redocly/replay/-/replay-0.16.1.tgz",
+      "integrity": "sha512-Rbtw617hyajCCB60/ngmUjk4ziMpwsj/6breAC0O0H9P+GNsELZJdxcWGE02YhwG2rxgMBFAzKyA5M0V5V6w8A==",
       "dependencies": {
         "@codemirror/autocomplete": "^6.15.0",
         "@codemirror/lang-html": "^6.4.7",
@@ -3536,7 +3536,7 @@
         "usehooks-ts": "^3.1.1"
       },
       "peerDependencies": {
-        "@redocly/theme": "0.57.0",
+        "@redocly/theme": "0.57.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^6.21.1",
@@ -3584,13 +3584,13 @@
       }
     },
     "node_modules/@redocly/theme": {
-      "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/@redocly/theme/-/theme-0.57.0.tgz",
-      "integrity": "sha512-YNLPmDTWrQ9kMnsrryS3I8Y28bWJBy1aZScEoYoe9MXBastX22I3rYUJqGvIihEoqZjPNEu2RpA7J5bA4gh2cg==",
+      "version": "0.57.1",
+      "resolved": "https://registry.npmjs.org/@redocly/theme/-/theme-0.57.1.tgz",
+      "integrity": "sha512-d4ocHjmyWOjt0wfJyzeCQyqek0gRazyETpZ87VPOscBNrdaAmP1efZqX6POZTWyE5upwzhuqZim6Jqn0S0K4fw==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@redocly/config": "0.29.0",
-        "@redocly/realm-asyncapi-sdk": "0.3.0",
+        "@redocly/realm-asyncapi-sdk": "0.4.0",
         "@tanstack/react-query": "5.62.3",
         "@tanstack/react-virtual": "3.13.0",
         "@xyflow/react": "^12.8.2",
@@ -4664,21 +4664,21 @@
       }
     },
     "node_modules/@uiw/codemirror-theme-material": {
-      "version": "4.25.1",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-material/-/codemirror-theme-material-4.25.1.tgz",
-      "integrity": "sha512-nBHzL3jt3xYs0RsBEBkOUdeAdvpfFJChEzTmG+DSS1++O8LcJDbXWxz5+2HETW1Gha3jWRZUyySH1dmsqyWPQw==",
+      "version": "4.25.2",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-material/-/codemirror-theme-material-4.25.2.tgz",
+      "integrity": "sha512-IDN/TN8xul6QduarhQ1khD2WFHyPUYmjxBq8Z8w249ltahFo+QT/H7DcuityTijWgnSg5CRPXHL6CQLDOumZcg==",
       "license": "MIT",
       "dependencies": {
-        "@uiw/codemirror-themes": "4.25.1"
+        "@uiw/codemirror-themes": "4.25.2"
       },
       "funding": {
         "url": "https://jaywcjlove.github.io/#/sponsor"
       }
     },
     "node_modules/@uiw/codemirror-themes": {
-      "version": "4.25.1",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-themes/-/codemirror-themes-4.25.1.tgz",
-      "integrity": "sha512-6o8tQ8bdq14RuVFpZ7l9u8KnuPq824uG3U1VV933Uhv8mfaxaoaOQSjv6T2bQUPhjH6ZlEu5+tAMkOfIL21eIQ==",
+      "version": "4.25.2",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-themes/-/codemirror-themes-4.25.2.tgz",
+      "integrity": "sha512-WFYxW3OlCkMomXQBlQdGj1JZ011UNCa7xYdmgYqywVc4E8f5VgIzRwCZSBNVjpWGGDBOjc+Z6F65l7gttP16pg==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
@@ -5158,9 +5158,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "overrides": {
     "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "axios": "1.12.2"
   }
 }


### PR DESCRIPTION
## What/Why/How?

- Fixed axios vulnerability from @redocly/realm (0.125.3) => typesense (2.1.0 latest)
- Run `npm i` to update realm (realm was updated already in package.json)

## Reference

- fixes: https://github.com/Redocly/website/security/dependabot/10

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
