### PR TITLE
docs(all): add info on path parameter support

### DIFF
--- a/learn/markdoc/tags/openapi-code-sample.md
+++ b/learn/markdoc/tags/openapi-code-sample.md
@@ -76,7 +76,7 @@ With `pointer`:
 
 - `parameters`
 - Object
-- Custom parameters to use for the OpenAPI operation code sample. Accepts values for `header` and `query`.
+- Custom parameters to use for the OpenAPI operation code sample. Accepts values for `header` and `query`, and predefined path parameters.
 
 ---
 


### PR DESCRIPTION
## What/Why/How?

Adds information about path parameters support in `openapi-code-sample` Markdoc tag.

Closes [#17950](https://github.com/Redocly/redocly/issues/17950)

## Check yourself

- [ ] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
