### PR TITLE
chore: update csp to remove rudder and support ga wildcards

### DIFF
--- a/redocly.yaml
+++ b/redocly.yaml
@@ -180,7 +180,6 @@ responseHeaders:
           https://www.google.com/recaptcha/ 
           https://www.gstatic.com/recaptcha/
           https://www.googletagmanager.com
-          https://cdn.rudderlabs.com
           https://cdn.usefathom.com
           https://www.clarity.ms
           https://js.hscollectedforms.net
@@ -204,14 +203,12 @@ responseHeaders:
         connect-src 
           'self'
           https://webhook.frontapp.com
-          https://api.rudderstack.com
           https://j.clarity.ms
           https://api.github.com
           https://api.rebilly.com
           https://forms.hsforms.com
           https://forms.hscollectedforms.net
-          https://www.google-analytics.com
-          https://redoclyrozwmb.dataplane.rudderstack.com
+          https://*.google-analytics.com
           https://hubspot-forms-static-embed.s3.amazonaws.com
           https://v.clarity.ms/collect;
         form-action 


### PR DESCRIPTION
## What/Why/How?

- Add wildcard support for google-analytics.com domain. Google is using subdomains like region1.google-analytics.com, etc..  This
- Remove rudder (not used any longer)

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
