### PR TITLE
chore: remove axios from overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   },
   "overrides": {
     "react": "19.2.4",
-    "react-dom": "19.2.4",
-    "axios": "1.15.0"
+    "react-dom": "19.2.4"
   }
 }


### PR DESCRIPTION
## What/Why/How?
The `axios` package is provided via the `realm` → `typesense` dependency chain. If there are any vulnerabilities or issues, they should be addressed on the `realm` side rather than overridden here.

I tested the changes, and everything works as expected. Therefore, there is no need to keep the override in this repository.

There are no changes to `package-lock.json`, as it was already updated to version `1.15.0` in [this commit](https://github.com/Redocly/website/commit/aeea9b153c897841f98a1e687b33c56b98869b24).

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
