### PR TITLE
chore(other): bump marketing pages to 0.2.2 and realm to 0.135.0-next.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "UNLICENSED",
       "dependencies": {
-        "@redocly/marketing-pages": "0.2.1",
+        "@redocly/marketing-pages": "0.2.2",
         "@redocly/realm": "0.134.0-next.5",
         "buffer": "^6.0.3",
         "highlight-words-core": "^1.2.3",
@@ -3317,9 +3317,9 @@
       "license": "SEE LICENSE IN LICENSE"
     },
     "node_modules/@redocly/marketing-pages": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@redocly/marketing-pages/-/marketing-pages-0.2.1.tgz",
-      "integrity": "sha512-0tDARf0seuuDE2qZujfsA1IY7R+ossadChOpc8CS+EtoMhItvgz149J9KuMb3UIKJkf7XjS0thI3Gzo9PtQNVA==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@redocly/marketing-pages/-/marketing-pages-0.2.2.tgz",
+      "integrity": "sha512-2o09KUH2KXuK83Hq35/LVZgVYMns4ors7XEzDQybFSiGpUWZMutPmokMtmmQQjEIyr1yLYT9rIVcRosDFUq2dQ==",
       "license": "UNLICENSED",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.1",
@@ -3337,7 +3337,7 @@
         "framer-motion": "^12.10.5",
         "highlight-words-core": "1.2.2",
         "html2canvas": "^1.4.1",
-        "js-cookie": "^2.2.1",
+        "js-cookie": "^3.0.6",
         "js-yaml": "4.1.1",
         "json-schema-to-ts": "^3.1.0",
         "jspdf": "^4.2.1",
@@ -3359,7 +3359,7 @@
         "ulid": "^2.3.0"
       },
       "peerDependencies": {
-        "@redocly/realm": ">=0.134.0-next.0",
+        "@redocly/realm": ">=0.135.0-next.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "styled-components": "^6.4.2"
@@ -3369,6 +3369,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/highlight-words-core/-/highlight-words-core-1.2.2.tgz",
       "integrity": "sha512-BXUKIkUuh6cmmxzi5OIbUJxrG8OAk2MqoL1DtO3Wo9D2faJg2ph5ntyuQeLqaHJmzER6H5tllCDA9ZnNe9BVGg==",
+      "license": "MIT"
+    },
+    "node_modules/@redocly/marketing-pages/node_modules/js-cookie": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.8.tgz",
+      "integrity": "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==",
       "license": "MIT"
     },
     "node_modules/@redocly/marketing-pages/node_modules/monaco-editor": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@redocly/marketing-pages": "0.2.2",
-        "@redocly/realm": "0.134.0-next.5",
+        "@redocly/realm": "0.135.0-next.0",
         "buffer": "^6.0.3",
         "highlight-words-core": "^1.2.3",
         "path": "^0.12.7",
@@ -3205,16 +3205,16 @@
       }
     },
     "node_modules/@redocly/asyncapi-docs": {
-      "version": "1.11.0-next.4",
-      "resolved": "https://registry.npmjs.org/@redocly/asyncapi-docs/-/asyncapi-docs-1.11.0-next.4.tgz",
-      "integrity": "sha512-/JjG6/Jh95uUWjEQa9Jc3U4jKHWN/8BH6UBjVx9xsuLEoH87V2GF+9TDl+xQsI9xZjMK2oc0FALtbFUDnvF2Fw==",
+      "version": "1.12.0-next.0",
+      "resolved": "https://registry.npmjs.org/@redocly/asyncapi-docs/-/asyncapi-docs-1.12.0-next.0.tgz",
+      "integrity": "sha512-Nh70E78/Tmph3PDNrsFhaF3dZDxAN6dBgBFdS2M2KhShTh2WDwyUdRRdMdl0+KHzmDgnHcD5S0hrnQ2w11oxJA==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@markdoc/markdoc": "0.5.2",
         "@redocly/config": "0.49.0",
-        "@redocly/openapi-docs": "3.22.0-next.4",
+        "@redocly/openapi-docs": "3.23.0-next.0",
         "@redocly/redoc-opentelemetry": "0.2.0",
-        "@redocly/theme": "0.66.0-next.4",
+        "@redocly/theme": "0.67.0-next.0",
         "jotai": "^2.11.1",
         "openapi-sampler": "^1.7.2",
         "react-router-dom": "^6.30.3",
@@ -3255,20 +3255,20 @@
       "license": "MIT"
     },
     "node_modules/@redocly/graphql-docs": {
-      "version": "1.11.0-next.4",
-      "resolved": "https://registry.npmjs.org/@redocly/graphql-docs/-/graphql-docs-1.11.0-next.4.tgz",
-      "integrity": "sha512-FBDxOXmYWiksusrJSMxtfo0P+oyP7PNdJqfGx8PY/ZEHWFgxiFy3e/w8y8qn0JvPJaFKMlk3qcTrL9bWJAluhQ==",
+      "version": "1.12.0-next.0",
+      "resolved": "https://registry.npmjs.org/@redocly/graphql-docs/-/graphql-docs-1.12.0-next.0.tgz",
+      "integrity": "sha512-NpW4pDVjR7FsEQIMWLos1T5LXTCDr4nvvB30+c6dWE3rzy7EZ1wdIvtg5cnDYAyPMz77dLJihnERJIeCgMzU8A==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@redocly/config": "0.49.0",
-        "@redocly/openapi-docs": "3.22.0-next.4",
+        "@redocly/openapi-docs": "3.23.0-next.0",
         "@redocly/redoc-opentelemetry": "0.2.0",
         "deepmerge": "^4.2.2",
         "marked": "^4.0.15",
         "web-vitals": "3.3.1"
       },
       "peerDependencies": {
-        "@redocly/theme": "0.66.0-next.4",
+        "@redocly/theme": "0.67.0-next.0",
         "graphql": "16.12.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -3289,22 +3289,22 @@
       }
     },
     "node_modules/@redocly/hookstate-core": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@redocly/hookstate-core/-/hookstate-core-4.2.3.tgz",
-      "integrity": "sha512-1S/E5S1mhFj5WG9ob6hv5CXKf99x4QY8TdknWZ4ByH+9emmqIfaKrPFVUSMl2Pbu5hp74rHffK0p8v74rGC65A==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@redocly/hookstate-core/-/hookstate-core-4.2.4.tgz",
+      "integrity": "sha512-N+0DkPva4oJXPocDqW8GSRcbKP6J9243lj3jpC34d/kJQgW6k83eudyJFzeq2MFZ5GplbTMm27CF+rng3ReS5Q==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.6 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@redocly/hookstate-devtools": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@redocly/hookstate-devtools/-/hookstate-devtools-4.2.0.tgz",
-      "integrity": "sha512-83u/kqVD5v0m99okmHiNT/d7uGmIIxx4TOrX9IhwfPP7Oc9gk7rCicOlkDZx5nomVVaE7380Ivku624aX6YWUw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@redocly/hookstate-devtools/-/hookstate-devtools-4.2.1.tgz",
+      "integrity": "sha512-YA9WNRug0TNQjxoS4krH8vliCZvy6XkN4ULBWSr2YQwUciHUUx6gMMwGC42gKNzq1d3A/zzC2Z98t+st9eeDPQ==",
       "license": "MIT",
       "dependencies": {
-        "redux": "4.2.0",
-        "redux-devtools-extension": "2.13.9"
+        "@redux-devtools/extension": "3.3.0",
+        "redux": "4.2.0"
       },
       "peerDependencies": {
         "@redocly/hookstate-core": "^4.0.0"
@@ -3419,9 +3419,9 @@
       }
     },
     "node_modules/@redocly/mock-server": {
-      "version": "0.8.0-next.2",
-      "resolved": "https://registry.npmjs.org/@redocly/mock-server/-/mock-server-0.8.0-next.2.tgz",
-      "integrity": "sha512-fia1Yk806/e2utMqI3K/bwDxtyV33Rc27Deb3ZSOLUgcYkVKvs5fppdZceHzmF0PFJIrLUUaTQiqVgGiamf6aA==",
+      "version": "0.9.0-next.0",
+      "resolved": "https://registry.npmjs.org/@redocly/mock-server/-/mock-server-0.9.0-next.0.tgz",
+      "integrity": "sha512-Go3T3g8tXZxFG+d/++izugndlEnvH5fPPvAGInoZfMvpMbsZu/oaxWRpNYPriEkXxVvk6QDfpNT7mOZz0iGqeA==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@redocly/ajv": "8.18.0",
@@ -3492,9 +3492,9 @@
       }
     },
     "node_modules/@redocly/openapi-docs": {
-      "version": "3.22.0-next.4",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-docs/-/openapi-docs-3.22.0-next.4.tgz",
-      "integrity": "sha512-txCwDw/Bqg0cLuNz7wtZFJ4O8entPtD2hQqUG0l4/dbEsb5KRX/YAERhzb9/1qRdEaSaBuenR7g7NTKk2C9gYw==",
+      "version": "3.23.0-next.0",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-docs/-/openapi-docs-3.23.0-next.0.tgz",
+      "integrity": "sha512-0z5RDUcLr41Zze7ap8vr0jLtEzo3aYa8fkpe3ITASaX2vWaHm081GI04jmAEYVyWs91YYI7dk/8l4uE5EnZ/zw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@babel/core": "7.29.7",
@@ -3502,7 +3502,7 @@
         "@redocly/config": "0.49.0",
         "@redocly/openapi-core": "2.31.6",
         "@redocly/redoc-opentelemetry": "0.2.0",
-        "@redocly/replay": "0.25.0-next.4",
+        "@redocly/replay": "0.26.0-next.0",
         "deepmerge": "^4.2.2",
         "dompurify": "3.4.0",
         "fast-deep-equal": "^3.1.3",
@@ -3525,7 +3525,7 @@
         "npm": ">=10.0.0"
       },
       "peerDependencies": {
-        "@redocly/theme": ">=0.66.0-next.0",
+        "@redocly/theme": ">=0.67.0-next.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "styled-components": "^4.1.1 || ^5.3.11 || ^6.0.0"
@@ -3548,9 +3548,9 @@
       }
     },
     "node_modules/@redocly/portal-legacy-ui": {
-      "version": "0.17.0-next.1",
-      "resolved": "https://registry.npmjs.org/@redocly/portal-legacy-ui/-/portal-legacy-ui-0.17.0-next.1.tgz",
-      "integrity": "sha512-57BSNMBrn467TpwH+4Kg7ODbqQFTq+5jRhKQkCpajb5qQjJesxmqWH+dJGA7E15Bjyc6TXaX/Jenn50zvUrV1A==",
+      "version": "0.18.0-next.0",
+      "resolved": "https://registry.npmjs.org/@redocly/portal-legacy-ui/-/portal-legacy-ui-0.18.0-next.0.tgz",
+      "integrity": "sha512-WeYXCP5mLTKWmHtZYtKKe7H5ERfA/FxDrfkwa5/Bx82sDGSLi5tTShbZlNjYoyQpSCkKGfvfFhEx4bbxnlUe+Q==",
       "license": "SEE LICENSE IN LICENSE",
       "peerDependencies": {
         "highlight-words-core": "^1.2.2",
@@ -3561,20 +3561,20 @@
       }
     },
     "node_modules/@redocly/portal-plugin-mock-server": {
-      "version": "0.19.0-next.4",
-      "resolved": "https://registry.npmjs.org/@redocly/portal-plugin-mock-server/-/portal-plugin-mock-server-0.19.0-next.4.tgz",
-      "integrity": "sha512-bU4g8dSlUj7ScazI2o8lAh5xlxTqJ24iVuQEBPrEqPRYiENEqvnO41e9q39zKhqzQ91obJqYnNg8CLUYiUmZTg==",
+      "version": "0.20.0-next.0",
+      "resolved": "https://registry.npmjs.org/@redocly/portal-plugin-mock-server/-/portal-plugin-mock-server-0.20.0-next.0.tgz",
+      "integrity": "sha512-oAvyCMCiNNbTegYp9ek+Wr1rtCUYhzlluNTP6KXbH4jAsmAjfOHBKnN6Pl1ieyKGPBW4QFoCn9t84Kec4eXWyA==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@redocly/config": "0.49.0",
-        "@redocly/mock-server": "0.8.0-next.2",
-        "@redocly/openapi-docs": "3.22.0-next.4"
+        "@redocly/mock-server": "0.9.0-next.0",
+        "@redocly/openapi-docs": "3.23.0-next.0"
       }
     },
     "node_modules/@redocly/realm": {
-      "version": "0.134.0-next.5",
-      "resolved": "https://registry.npmjs.org/@redocly/realm/-/realm-0.134.0-next.5.tgz",
-      "integrity": "sha512-sfoQUo+IEkLFz6gwo6NJCkPlKUWlPLIwefoRsV2KUuHesBjB/AY12RCKsRlsElCMvJqbznQTXiJxRUpn+2ga9g==",
+      "version": "0.135.0-next.0",
+      "resolved": "https://registry.npmjs.org/@redocly/realm/-/realm-0.135.0-next.0.tgz",
+      "integrity": "sha512-1h6N7/TF0ErbFrZu2liBvnlvz1rPcuefBTTswu75pDbeOtbK0JNCyVreCDTJ9H9BjW9uUaK/bRI2qv8jS8JuHw==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@babel/core": "7.29.7",
@@ -3593,16 +3593,16 @@
         "@opentelemetry/sdk-trace-web": "2.6.1",
         "@opentelemetry/semantic-conventions": "1.40.0",
         "@redocly/ajv": "8.18.0",
-        "@redocly/asyncapi-docs": "1.11.0-next.4",
+        "@redocly/asyncapi-docs": "1.12.0-next.0",
         "@redocly/config": "0.49.0",
-        "@redocly/graphql-docs": "1.11.0-next.4",
+        "@redocly/graphql-docs": "1.12.0-next.0",
         "@redocly/mcp-typescript-sdk": "1.18.1",
         "@redocly/openapi-core": "2.31.6",
-        "@redocly/openapi-docs": "3.22.0-next.4",
-        "@redocly/portal-legacy-ui": "0.17.0-next.1",
-        "@redocly/portal-plugin-mock-server": "0.19.0-next.4",
-        "@redocly/realm-asyncapi-sdk": "0.12.0-next.3",
-        "@redocly/theme": "0.66.0-next.4",
+        "@redocly/openapi-docs": "3.23.0-next.0",
+        "@redocly/portal-legacy-ui": "0.18.0-next.0",
+        "@redocly/portal-plugin-mock-server": "0.20.0-next.0",
+        "@redocly/realm-asyncapi-sdk": "0.13.0-next.0",
+        "@redocly/theme": "0.67.0-next.0",
         "@shikijs/transformers": "3.21.0",
         "@tanstack/react-query": "5.62.3",
         "@tanstack/react-table": "8.21.3",
@@ -3625,7 +3625,7 @@
         "flexsearch": "0.7.43",
         "graphql": "16.12.0",
         "gray-matter": "4.0.3",
-        "hono": "4.12.18",
+        "hono": "4.12.23",
         "htmlparser2": "8.0.2",
         "i18next": "22.4.15",
         "is-glob": "4.0.3",
@@ -3676,9 +3676,9 @@
       }
     },
     "node_modules/@redocly/realm-asyncapi-sdk": {
-      "version": "0.12.0-next.3",
-      "resolved": "https://registry.npmjs.org/@redocly/realm-asyncapi-sdk/-/realm-asyncapi-sdk-0.12.0-next.3.tgz",
-      "integrity": "sha512-kfAcT0G41zqP2tQ+GWIpudGjD6E3yj5qxzSGPcQPhpoaQ3mBk2dULUnnypqZiunG3AujwuapsnVl9azhh1QHQg==",
+      "version": "0.13.0-next.0",
+      "resolved": "https://registry.npmjs.org/@redocly/realm-asyncapi-sdk/-/realm-asyncapi-sdk-0.13.0-next.0.tgz",
+      "integrity": "sha512-DHm+yzBe58O4bChfqgPVWp+BP3rKhct1hU/WByWRAAVO928a7yXCoYMgAhR18upuhkw9So3NQMYQGo8Gz3phDg==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "safe-stable-stringify": "2.5.0"
@@ -3725,9 +3725,9 @@
       "license": "MIT"
     },
     "node_modules/@redocly/replay": {
-      "version": "0.25.0-next.4",
-      "resolved": "https://registry.npmjs.org/@redocly/replay/-/replay-0.25.0-next.4.tgz",
-      "integrity": "sha512-C5ndyn1sKhjcyGB4kuETbHksUjbiJCv97omPqyPUmsVfS7sTCDqEoqhFUtM6tFIfktUyh8CDAybdub3nn/dRBg==",
+      "version": "0.26.0-next.0",
+      "resolved": "https://registry.npmjs.org/@redocly/replay/-/replay-0.26.0-next.0.tgz",
+      "integrity": "sha512-E3ByZUWPzK7QPo/XbE/Of7MhkZNU8MqgxJD9e9YPB2xu26biX900B2+WJPDGh8dRH3wjLVxDzKu6EfrEeIELeA==",
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.1",
         "@ai-sdk/google": "3.0.1",
@@ -3754,8 +3754,8 @@
         "@lezer/highlight": "^1.1.6",
         "@noble/hashes": "^1.8.0",
         "@opentelemetry/api": "1.9.0",
-        "@redocly/hookstate-core": "4.2.3",
-        "@redocly/hookstate-devtools": "^4.2.0",
+        "@redocly/hookstate-core": "^4.2.4",
+        "@redocly/hookstate-devtools": "^4.2.1",
         "@redocly/openapi-core": "2.31.6",
         "@redocly/respect-core": "2.31.6",
         "@redocly/vscode-json-languageservice": "^3.4.9",
@@ -3787,7 +3787,7 @@
         "zod": "^3.25.76"
       },
       "peerDependencies": {
-        "@redocly/theme": "0.66.0-next.4",
+        "@redocly/theme": "0.67.0-next.0",
         "@tanstack/react-query": "5.62.3",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -3838,9 +3838,9 @@
       "license": "MIT"
     },
     "node_modules/@redocly/theme": {
-      "version": "0.66.0-next.4",
-      "resolved": "https://registry.npmjs.org/@redocly/theme/-/theme-0.66.0-next.4.tgz",
-      "integrity": "sha512-X4jeMRuPhVa6lJsKhUc+zNZV5TcrynYLoqMRDHaaCSLOjTQKZRdR/sIPE+Wa9B+LCGkOBWUkPxbuTZzHN/d09A==",
+      "version": "0.67.0-next.0",
+      "resolved": "https://registry.npmjs.org/@redocly/theme/-/theme-0.67.0-next.0.tgz",
+      "integrity": "sha512-vJaP+xrLKjtk8seyK+XiVJV/GfK57m7akZlnb0OJoJP5I6yzjk+MKxVcoqUsH3LUIWSLDzEAOxOOf2hdw9t0QA==",
       "license": "MIT",
       "dependencies": {
         "@emotion/is-prop-valid": "^1.3.1",
@@ -3906,6 +3906,19 @@
       "resolved": "https://registry.npmjs.org/@redocly/yaml-language-server-parser/-/yaml-language-server-parser-0.3.0.tgz",
       "integrity": "sha512-u3Qe9uPRyTQi5Buytg+qkUlWwsujEN2rXT2X8U/Rw8jdFVxoudZxLTjVnp5fBMVxIFhjoqe3KIQZnR6f4VUFHg==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@redux-devtools/extension": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@redux-devtools/extension/-/extension-3.3.0.tgz",
+      "integrity": "sha512-X34S/rC8S/M1BIrkYD1mJ5f8vlH0BDqxXrs96cvxSBo4FhMdbhU+GUGsmNYov1xjSyLMHgo8NYrUG8bNX7525g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2",
+        "immutable": "^4.3.4"
+      },
+      "peerDependencies": {
+        "redux": "^3.1.0 || ^4.0.0 || ^5.0.0"
+      }
     },
     "node_modules/@remix-run/router": {
       "version": "1.23.3",
@@ -5030,6 +5043,18 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/anynum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
+      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/arg": {
       "version": "5.0.2",
@@ -7831,9 +7856,9 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -8022,6 +8047,12 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
+    "node_modules/immutable": {
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.8.tgz",
+      "integrity": "sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==",
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -11984,16 +12015,6 @@
         "@babel/runtime": "^7.9.2"
       }
     },
-    "node_modules/redux-devtools-extension": {
-      "version": "2.13.9",
-      "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.9.tgz",
-      "integrity": "sha512-cNJ8Q/EtjhQaZ71c8I9+BPySIBVEKssbPpskBfsXqb8HJ002A3KRVHfeRzwRo6mGPqsm7XuHTqNSNeS1Khig0A==",
-      "deprecated": "Package moved to @redux-devtools/extension.",
-      "license": "MIT",
-      "peerDependencies": {
-        "redux": "^3.1.0 || ^4.0.0"
-      }
-    },
     "node_modules/reftools": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/reftools/-/reftools-1.1.9.tgz",
@@ -12796,16 +12817,19 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
-      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
+      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.0"
+      }
     },
     "node_modules/style-mod": {
       "version": "4.1.3",
@@ -13717,9 +13741,9 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.21",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.21.tgz",
-      "integrity": "sha512-zbRA8cVm6io/d5W8uIe2hblzN76/Wm3v/yiythQvr+dpBWeqhPSWIDNj4zOyHi4zKbMK6DN34Xsr9jPHJERAEw==",
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "UNLICENSED",
   "dependencies": {
     "@redocly/marketing-pages": "0.2.2",
-    "@redocly/realm": "0.134.0-next.5",
+    "@redocly/realm": "0.135.0-next.0",
     "buffer": "^6.0.3",
     "highlight-words-core": "^1.2.3",
     "path": "^0.12.7",
@@ -33,6 +33,6 @@
   "overrides": {
     "react": "19.2.4",
     "react-dom": "19.2.4",
-    "@redocly/realm": "0.134.0-next.5"
+    "@redocly/realm": "0.135.0-next.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "team@redocly.com",
   "license": "UNLICENSED",
   "dependencies": {
-    "@redocly/marketing-pages": "0.2.1",
+    "@redocly/marketing-pages": "0.2.2",
     "@redocly/realm": "0.134.0-next.5",
     "buffer": "^6.0.3",
     "highlight-words-core": "^1.2.3",


### PR DESCRIPTION
## What/Why/How?
- fix the `CVE-2026-46625` (new version bump the js-cookie)

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
