### PR TITLE
chore(other): resolve shell-quote and js-cookie CVE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8573,10 +8573,13 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/js-cookie": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
-      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
-      "license": "MIT"
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz",
+      "integrity": "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/js-levenshtein": {
       "version": "1.1.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12414,9 +12414,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "peer": true,
       "engines": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "overrides": {
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "shell-quote": "^1.8.4",
     "@redocly/realm": "0.135.0-next.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   "overrides": {
     "react": "19.2.4",
     "react-dom": "19.2.4",
-    "shell-quote": "^1.8.4",
+    "shell-quote@<1.8.3": "1.8.4",
+    "js-cookie@<3.0.7": "3.0.7",
     "@redocly/realm": "0.135.0-next.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "overrides": {
     "react": "19.2.4",
     "react-dom": "19.2.4",
-    "shell-quote@<1.8.3": "1.8.4",
+    "shell-quote@<1.8.4": "1.8.4",
     "js-cookie@<3.0.7": "3.0.7",
     "@redocly/realm": "0.135.0-next.0"
   }


### PR DESCRIPTION
## What/Why/How?
- bump shell-quote to 1.8.4 to fix CVE-2026-9277
- bump js-cookie to 3.0.7 to fix CVE-2026-46625

## Reference
- https://github.com/Redocly/website/security/dependabot/150
- https://github.com/Redocly/website/security/dependabot/143

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
