### PR TITLE
chore(deps): bump marketing-pages version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "UNLICENSED",
       "dependencies": {
-        "@redocly/marketing-pages": "0.2.5",
+        "@redocly/marketing-pages": "0.2.8",
         "@redocly/realm": "0.135.0-next.5",
         "buffer": "^6.0.3",
         "highlight-words-core": "^1.2.3",
@@ -2735,8 +2735,8 @@
       "license": "SEE LICENSE IN LICENSE"
     },
     "node_modules/@redocly/marketing-pages": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@redocly/marketing-pages/-/marketing-pages-0.2.5.tgz",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@redocly/marketing-pages/-/marketing-pages-0.2.8.tgz",
       "integrity": "sha512-HwVD5IspdMAW/V2aNyYLyS1uz5/53X8Llg6atqVTt4EQsUvnH5OG29deWeWVbGE7dRVWzjqxBATgjbg8Rc7RWw==",
       "license": "UNLICENSED",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "team@redocly.com",
   "license": "UNLICENSED",
   "dependencies": {
-    "@redocly/marketing-pages": "0.2.5",
+    "@redocly/marketing-pages": "0.2.8",
     "@redocly/realm": "0.135.0-next.5",
     "buffer": "^6.0.3",
     "highlight-words-core": "^1.2.3",


### PR DESCRIPTION
## What/Why/How?
Bump marketing-pages version to the latest - v0.2.8
## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
