### PR TITLE
chore(deps): bump realm to 0.135.0-next.6 and marketing-pages to 0.2.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@redocly/marketing-pages": "0.2.5",
-        "@redocly/realm": "0.135.0-next.5",
+        "@redocly/realm": "0.135.0-next.6",
         "buffer": "^6.0.3",
         "highlight-words-core": "^1.2.3",
         "path": "^0.12.7",
@@ -1809,9 +1809,9 @@
       "license": "MIT"
     },
     "node_modules/@lezer/css": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.3.tgz",
-      "integrity": "sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.4.tgz",
+      "integrity": "sha512-N+tn9tej2hPvyKgHEApMOQfHczDJCwxrRFS3SPn9QjYN+uwHvEDnCgKRrb3mxDYxRS8sKMM8fhC3+lc04Abz5Q==",
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.2.0",
@@ -2623,16 +2623,16 @@
       }
     },
     "node_modules/@redocly/asyncapi-docs": {
-      "version": "1.12.0-next.5",
-      "resolved": "https://registry.npmjs.org/@redocly/asyncapi-docs/-/asyncapi-docs-1.12.0-next.5.tgz",
-      "integrity": "sha512-IoZDI22Pe2rAFMfxVR1r+FVUC0/+HZUIxeZ7CfY7H4jH3Xc4kjjoczyB2a4SUq6+Olqk4yVponnHZf9sm82efg==",
+      "version": "1.12.0-next.6",
+      "resolved": "https://registry.npmjs.org/@redocly/asyncapi-docs/-/asyncapi-docs-1.12.0-next.6.tgz",
+      "integrity": "sha512-KlAwjwRztAjMYo4RdQ7mfjQacC9k6KRkPABtjwUQN9Fy2FnbEtqeqAYSC4lwgkiZrgqNqkPmd6w28lRW3LYxzg==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@markdoc/markdoc": "0.5.2",
-        "@redocly/config": "0.49.0",
-        "@redocly/openapi-docs": "3.23.0-next.5",
-        "@redocly/redoc-opentelemetry": "0.2.1",
-        "@redocly/theme": "0.67.0-next.4",
+        "@redocly/config": "0.49.1",
+        "@redocly/openapi-docs": "3.23.0-next.6",
+        "@redocly/redoc-opentelemetry": "0.2.2",
+        "@redocly/theme": "0.67.0-next.5",
         "jotai": "^2.11.1",
         "openapi-sampler": "^1.7.2",
         "react-router-dom": "^6.30.3",
@@ -2642,6 +2642,74 @@
       "peerDependencies": {
         "react": "^19.2.4"
       }
+    },
+    "node_modules/@redocly/asyncapi-docs/node_modules/@redocly/config": {
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.49.1.tgz",
+      "integrity": "sha512-Eid8/bDcsf2bpTJ2qZhULflf6Y/TtoUFZt0+a5XZzjZj0uA8L8EQiY/nEdBd6lZQlZsnu8/cAUhTyBebnLi0gA==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "2.7.2"
+      }
+    },
+    "node_modules/@redocly/asyncapi-docs/node_modules/@redocly/theme": {
+      "version": "0.67.0-next.5",
+      "resolved": "https://registry.npmjs.org/@redocly/theme/-/theme-0.67.0-next.5.tgz",
+      "integrity": "sha512-pCSlbXWSYWnSV34nUKYCO7K0+4995GcxzBACVK+81N/fBSMiv/2xeBavze2I/tUHzD4dLTXotvTtRqC6Xy4qmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/config": "0.49.1",
+        "@tanstack/react-query": "5.62.3",
+        "@tanstack/react-virtual": "3.13.0",
+        "@xyflow/react": "^12.8.2",
+        "copy-to-clipboard": "3.3.3",
+        "file-saver": "2.0.5",
+        "highlight-words-core": "1.2.2",
+        "hotkeys-js": "3.10.1",
+        "i18next": "22.4.15",
+        "jszip": "3.10.1",
+        "lodash.debounce": "^4.0.8",
+        "lodash.throttle": "4.1.1",
+        "nprogress": "0.2.0",
+        "openapi-sampler": "^1.7.2",
+        "react-calendar": "5.1.0",
+        "react-date-picker": "11.0.0"
+      },
+      "peerDependencies": {
+        "@markdoc/markdoc": "0.5.2",
+        "lodash.debounce": "^4.0.8",
+        "lodash.throttle": "^4.1.1",
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4",
+        "react-router-dom": "^6.30.3",
+        "styled-components": "^4.1.1 || ^5.3.11 || ^6.0.0"
+      }
+    },
+    "node_modules/@redocly/asyncapi-docs/node_modules/highlight-words-core": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/highlight-words-core/-/highlight-words-core-1.2.2.tgz",
+      "integrity": "sha512-BXUKIkUuh6cmmxzi5OIbUJxrG8OAk2MqoL1DtO3Wo9D2faJg2ph5ntyuQeLqaHJmzER6H5tllCDA9ZnNe9BVGg==",
+      "license": "MIT"
+    },
+    "node_modules/@redocly/asyncapi-docs/node_modules/json-schema-to-ts": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-2.7.2.tgz",
+      "integrity": "sha512-R1JfqKqbBR4qE8UyBR56Ms30LL62/nlhoz+1UkfI/VE7p54Awu919FZ6ZUPG8zIa3XB65usPJgr1ONVncUGSaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@types/json-schema": "^7.0.9",
+        "ts-algebra": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@redocly/asyncapi-docs/node_modules/ts-algebra": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-1.2.2.tgz",
+      "integrity": "sha512-kloPhf1hq3JbCPOTYoOWDKxebWjNb2o/LKnNfkWhxVVisFFmMJPPdJeGoGmM+iRLyoXAR61e08Pb+vUXINg8aA==",
+      "license": "MIT"
     },
     "node_modules/@redocly/config": {
       "version": "0.49.0",
@@ -2671,40 +2739,6 @@
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-1.2.2.tgz",
       "integrity": "sha512-kloPhf1hq3JbCPOTYoOWDKxebWjNb2o/LKnNfkWhxVVisFFmMJPPdJeGoGmM+iRLyoXAR61e08Pb+vUXINg8aA==",
       "license": "MIT"
-    },
-    "node_modules/@redocly/graphql-docs": {
-      "version": "1.12.0-next.5",
-      "resolved": "https://registry.npmjs.org/@redocly/graphql-docs/-/graphql-docs-1.12.0-next.5.tgz",
-      "integrity": "sha512-ZXYvaKmvgmh866NB7aB378TQneqQndKZ60JZAcH0+EAh52U4iX0dCMtR3vWuPRdEP4NfzUTpeZKVZV0O0oUX6g==",
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@redocly/config": "0.49.0",
-        "@redocly/openapi-docs": "3.23.0-next.5",
-        "@redocly/redoc-opentelemetry": "0.2.1",
-        "deepmerge": "^4.2.2",
-        "marked": "^4.0.15",
-        "web-vitals": "3.3.1"
-      },
-      "peerDependencies": {
-        "@redocly/theme": "0.67.0-next.4",
-        "graphql": "16.12.0",
-        "react": "^19.2.4",
-        "react-dom": "^19.2.4",
-        "react-router-dom": "^6.30.3",
-        "styled-components": "^5.3.11 || ^6.0.0"
-      }
-    },
-    "node_modules/@redocly/graphql-docs/node_modules/marked": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
     },
     "node_modules/@redocly/hookstate-core": {
       "version": "4.2.4",
@@ -2860,13 +2894,13 @@
       }
     },
     "node_modules/@redocly/mock-server": {
-      "version": "0.9.0-next.3",
-      "resolved": "https://registry.npmjs.org/@redocly/mock-server/-/mock-server-0.9.0-next.3.tgz",
-      "integrity": "sha512-WWvdnS6/7yaQDq9pCYT3pLTikhrSKtQdabI7PI4NOIQfS+xeBIImYPl5Be6Oosy73PIDcWRY1SK3eW2Gsl3vaQ==",
+      "version": "0.9.0-next.4",
+      "resolved": "https://registry.npmjs.org/@redocly/mock-server/-/mock-server-0.9.0-next.4.tgz",
+      "integrity": "sha512-/VpurFi+c5I4pa3VYOymiBnvQL8gSYeoyGnySKsd4wYN7mrGoWIft6Gmg/v1zs59wTIWHcwFFYi0OjTSIv2SJw==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@redocly/ajv": "8.18.0",
-        "@redocly/openapi-core": "2.34.0",
+        "@redocly/openapi-core": "2.35.0",
         "ajv": "8.18.0",
         "ajv-formats": "^3.0.1",
         "fast-xml-parser": "5.7.3",
@@ -2882,6 +2916,61 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-F+LMD2IDIXuHxgpLJh3nkLj9+tSaEzoUWd+7fONGq5pe2169FUDjpEkOfEpoGLz1sbZni/69p07OsecNfAOpqA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@redocly/mock-server/node_modules/@redocly/openapi-core": {
+      "version": "2.35.0",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.35.0.tgz",
+      "integrity": "sha512-QAMFYwPFyunIe8MD6OTKlp2NXhuRy+90LJd1iUJgtlKR1YRYIpibeHVeiKTHULT5MFMSGiw0Bcv+IRTedt9stQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/ajv": "^8.18.1",
+        "@redocly/config": "^0.49.0",
+        "ajv": "npm:@redocly/ajv@8.18.1",
+        "ajv-formats": "^3.0.1",
+        "colorette": "^1.2.0",
+        "js-levenshtein": "^1.1.6",
+        "js-yaml": "^4.2.0",
+        "picomatch": "^4.0.4",
+        "pluralize": "^8.0.0",
+        "yaml-ast-parser": "0.0.43"
+      },
+      "engines": {
+        "node": ">=22.12.0 || >=20.19.0 <21.0.0",
+        "npm": ">=10"
+      }
+    },
+    "node_modules/@redocly/mock-server/node_modules/@redocly/openapi-core/node_modules/@redocly/ajv": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.3.tgz",
+      "integrity": "sha512-l42u0of3hY98sN2A+M4qTX1O/KrpgGH32Hu9kP2GtHyD5Dfqq86PKFLe5dwaD8DEnNmlOlll2BAmeEtf0DaySg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@redocly/mock-server/node_modules/@redocly/openapi-core/node_modules/ajv": {
+      "name": "@redocly/ajv",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.1.tgz",
+      "integrity": "sha512-Ifm/pP/tul1qmAecpbVxCBluVE32rKfjf8gYXH4xI2gCv9mRWFhJMHzkPDM4TXlxwPQYIFegymlsy8lXz7optA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -2937,6 +3026,7 @@
       "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.34.0.tgz",
       "integrity": "sha512-QHdrFT34zJLTwC1vG4QAwSzHMh2Ll545X/u5ScKzVPh8PPmjYVE+jMjVmwlRXyTPKWxOerqbPY7ZOACOCOSfbg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@redocly/ajv": "^8.18.1",
         "@redocly/config": "^0.49.0",
@@ -2969,6 +3059,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -2977,17 +3068,17 @@
       }
     },
     "node_modules/@redocly/openapi-docs": {
-      "version": "3.23.0-next.5",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-docs/-/openapi-docs-3.23.0-next.5.tgz",
-      "integrity": "sha512-wv8zzsZd0wkIzeFe+Gv6M/flVL+KyVfob7GNyjvAQWRlDlEiTz2ztM81RNBHGjomLCAlD8eiMS8kKY5LoBT6DQ==",
+      "version": "3.23.0-next.6",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-docs/-/openapi-docs-3.23.0-next.6.tgz",
+      "integrity": "sha512-kMUMv0mbEojaF9oDrfHCvvx1uYLL6irSBM2vrhAfr0SIcpPmtdHY9R5AzklQx3MhvSjgcLHGgweivb9HThUp9w==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@babel/core": "7.29.7",
         "@markdoc/markdoc": "0.5.2",
-        "@redocly/config": "0.49.0",
-        "@redocly/openapi-core": "2.34.0",
-        "@redocly/redoc-opentelemetry": "0.2.1",
-        "@redocly/replay": "0.26.0-next.5",
+        "@redocly/config": "0.49.1",
+        "@redocly/openapi-core": "2.35.0",
+        "@redocly/redoc-opentelemetry": "0.2.2",
+        "@redocly/replay": "0.26.0-next.6",
         "deepmerge": "^4.2.2",
         "dompurify": "3.4.11",
         "fast-deep-equal": "^3.1.3",
@@ -3014,6 +3105,210 @@
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "styled-components": "^4.1.1 || ^5.3.11 || ^6.0.0"
+      }
+    },
+    "node_modules/@redocly/openapi-docs/node_modules/@redocly/config": {
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.49.1.tgz",
+      "integrity": "sha512-Eid8/bDcsf2bpTJ2qZhULflf6Y/TtoUFZt0+a5XZzjZj0uA8L8EQiY/nEdBd6lZQlZsnu8/cAUhTyBebnLi0gA==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "2.7.2"
+      }
+    },
+    "node_modules/@redocly/openapi-docs/node_modules/@redocly/openapi-core": {
+      "version": "2.35.0",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.35.0.tgz",
+      "integrity": "sha512-QAMFYwPFyunIe8MD6OTKlp2NXhuRy+90LJd1iUJgtlKR1YRYIpibeHVeiKTHULT5MFMSGiw0Bcv+IRTedt9stQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/ajv": "^8.18.1",
+        "@redocly/config": "^0.49.0",
+        "ajv": "npm:@redocly/ajv@8.18.1",
+        "ajv-formats": "^3.0.1",
+        "colorette": "^1.2.0",
+        "js-levenshtein": "^1.1.6",
+        "js-yaml": "^4.2.0",
+        "picomatch": "^4.0.4",
+        "pluralize": "^8.0.0",
+        "yaml-ast-parser": "0.0.43"
+      },
+      "engines": {
+        "node": ">=22.12.0 || >=20.19.0 <21.0.0",
+        "npm": ">=10"
+      }
+    },
+    "node_modules/@redocly/openapi-docs/node_modules/@redocly/replay": {
+      "version": "0.26.0-next.6",
+      "resolved": "https://registry.npmjs.org/@redocly/replay/-/replay-0.26.0-next.6.tgz",
+      "integrity": "sha512-EH7bkhCaAxgTkUh+kpdh5vpxzMEOkvRfRcyjgDh8CW8girLwgVuUvRVeJ7Z9ZEOtpK5yi+BSjFIPyk4Jt8LrSA==",
+      "dependencies": {
+        "@ai-sdk/anthropic": "3.0.1",
+        "@ai-sdk/google": "3.0.1",
+        "@ai-sdk/openai": "3.0.1",
+        "@ai-sdk/provider": "3.0.0",
+        "@ai-sdk/react": "3.0.118",
+        "@codemirror/autocomplete": "^6.15.0",
+        "@codemirror/commands": "^6.9.0",
+        "@codemirror/lang-html": "^6.4.7",
+        "@codemirror/lang-java": "^6.0.2",
+        "@codemirror/lang-javascript": "^6.2.4",
+        "@codemirror/lang-json": "^6.0.1",
+        "@codemirror/lang-python": "^6.2.1",
+        "@codemirror/lang-xml": "^6.0.2",
+        "@codemirror/lang-yaml": "^6.1.2",
+        "@codemirror/language": "^6.11.3",
+        "@codemirror/legacy-modes": "^6.5.2",
+        "@codemirror/lint": "^6.5.0",
+        "@codemirror/search": "^6.5.11",
+        "@codemirror/state": "^6.5.2",
+        "@codemirror/view": "^6.25.1",
+        "@dnd-kit/core": "^6.1.0",
+        "@dnd-kit/sortable": "^8.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
+        "@lezer/highlight": "^1.1.6",
+        "@noble/hashes": "^1.8.0",
+        "@opentelemetry/api": "1.9.0",
+        "@redocly/hookstate-core": "^4.2.4",
+        "@redocly/hookstate-devtools": "^4.2.1",
+        "@redocly/openapi-core": "2.35.0",
+        "@redocly/respect-core": "2.35.0",
+        "@redocly/vscode-json-languageservice": "^3.4.9",
+        "@tauri-apps/api": "2.4.1",
+        "@tauri-apps/plugin-dialog": "2.0.0-rc.1",
+        "@tauri-apps/plugin-fs": "2.0.0-rc.2",
+        "@tauri-apps/plugin-opener": "^2.5.2",
+        "@uiw/codemirror-theme-material": "^4.21.20",
+        "@uiw/react-codemirror": "^4.21.20",
+        "ai": "6.0.111",
+        "dayjs": "1.11.21",
+        "diff": "^8.0.0",
+        "drizzle-orm": "^0.45.0",
+        "fast-xml-parser": "5.7.3",
+        "idb": "^8.0.2",
+        "js-yaml": "4.2.0",
+        "json-pointer": "^0.6.2",
+        "json-schema-typed": "^8.0.1",
+        "marked": "^4.0.15",
+        "p-queue": "^7.3.4",
+        "path-browserify": "^1.0.1",
+        "rc-tooltip": "^6.1.3",
+        "react-arborist": "3.4.0",
+        "react-resizable-panels": "^3.0.6",
+        "react-select": "5.10.1",
+        "shellwords": "^1.1.1",
+        "ulid": "^2.3.0",
+        "usehooks-ts": "^3.1.1",
+        "yaml": "^2.0.0",
+        "zod": "^3.25.76"
+      },
+      "peerDependencies": {
+        "@redocly/theme": "0.67.0-next.5",
+        "@tanstack/react-query": "5.62.3",
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4",
+        "react-router-dom": "^6.30.3",
+        "styled-components": "^6.4.2"
+      }
+    },
+    "node_modules/@redocly/openapi-docs/node_modules/@redocly/replay/node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@redocly/openapi-docs/node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/@redocly/openapi-docs/node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@redocly/openapi-docs/node_modules/json-schema-to-ts": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-2.7.2.tgz",
+      "integrity": "sha512-R1JfqKqbBR4qE8UyBR56Ms30LL62/nlhoz+1UkfI/VE7p54Awu919FZ6ZUPG8zIa3XB65usPJgr1ONVncUGSaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@types/json-schema": "^7.0.9",
+        "ts-algebra": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@redocly/openapi-docs/node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@redocly/openapi-docs/node_modules/ts-algebra": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-1.2.2.tgz",
+      "integrity": "sha512-kloPhf1hq3JbCPOTYoOWDKxebWjNb2o/LKnNfkWhxVVisFFmMJPPdJeGoGmM+iRLyoXAR61e08Pb+vUXINg8aA==",
+      "license": "MIT"
+    },
+    "node_modules/@redocly/openapi-docs/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/@redocly/openapi-language-server": {
@@ -3046,20 +3341,49 @@
       }
     },
     "node_modules/@redocly/portal-plugin-mock-server": {
-      "version": "0.20.0-next.5",
-      "resolved": "https://registry.npmjs.org/@redocly/portal-plugin-mock-server/-/portal-plugin-mock-server-0.20.0-next.5.tgz",
-      "integrity": "sha512-ovWk523GypeAFgsKU3pO3Qm9VyAW7KorK/nZwLH9TJabQfIfXFo6jTyciuulpnEDg5iQWqau5gFort0XpgFQPA==",
+      "version": "0.20.0-next.6",
+      "resolved": "https://registry.npmjs.org/@redocly/portal-plugin-mock-server/-/portal-plugin-mock-server-0.20.0-next.6.tgz",
+      "integrity": "sha512-EMUJuUJPjeMB7FAiQGycffZo/aEmM9mcbwVNn6qSulAIPqKIxd/3OynVIHuedowu/RnLCnkfuOqjaABpRoq/+Q==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@redocly/config": "0.49.0",
-        "@redocly/mock-server": "0.9.0-next.3",
-        "@redocly/openapi-docs": "3.23.0-next.5"
+        "@redocly/config": "0.49.1",
+        "@redocly/mock-server": "0.9.0-next.4",
+        "@redocly/openapi-docs": "3.23.0-next.6"
       }
     },
+    "node_modules/@redocly/portal-plugin-mock-server/node_modules/@redocly/config": {
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.49.1.tgz",
+      "integrity": "sha512-Eid8/bDcsf2bpTJ2qZhULflf6Y/TtoUFZt0+a5XZzjZj0uA8L8EQiY/nEdBd6lZQlZsnu8/cAUhTyBebnLi0gA==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "2.7.2"
+      }
+    },
+    "node_modules/@redocly/portal-plugin-mock-server/node_modules/json-schema-to-ts": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-2.7.2.tgz",
+      "integrity": "sha512-R1JfqKqbBR4qE8UyBR56Ms30LL62/nlhoz+1UkfI/VE7p54Awu919FZ6ZUPG8zIa3XB65usPJgr1ONVncUGSaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@types/json-schema": "^7.0.9",
+        "ts-algebra": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@redocly/portal-plugin-mock-server/node_modules/ts-algebra": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-1.2.2.tgz",
+      "integrity": "sha512-kloPhf1hq3JbCPOTYoOWDKxebWjNb2o/LKnNfkWhxVVisFFmMJPPdJeGoGmM+iRLyoXAR61e08Pb+vUXINg8aA==",
+      "license": "MIT"
+    },
     "node_modules/@redocly/realm": {
-      "version": "0.135.0-next.5",
-      "resolved": "https://registry.npmjs.org/@redocly/realm/-/realm-0.135.0-next.5.tgz",
-      "integrity": "sha512-UVFcc+/zZJM8YkOaD5y/roAeST1PAI6FA09fBn5Bdyy7b+Wx8+Ryt6+hydZ/v8jjoju3puvYZYM/dg/Sxq4mrg==",
+      "version": "0.135.0-next.6",
+      "resolved": "https://registry.npmjs.org/@redocly/realm/-/realm-0.135.0-next.6.tgz",
+      "integrity": "sha512-51XQ0GuzUXj2XyJNMTkt3Plkvr6sxqjIdOseIJ4OaqdT7ziBctvncxSw6qbso1Av1Ttly/j+Dizh1R/83MrXcw==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@babel/core": "7.29.7",
@@ -3080,16 +3404,16 @@
         "@opentelemetry/sdk-trace-web": "2.8.0",
         "@opentelemetry/semantic-conventions": "1.40.0",
         "@redocly/ajv": "8.18.0",
-        "@redocly/asyncapi-docs": "1.12.0-next.5",
-        "@redocly/config": "0.49.0",
-        "@redocly/graphql-docs": "1.12.0-next.5",
+        "@redocly/asyncapi-docs": "1.12.0-next.6",
+        "@redocly/config": "0.49.1",
+        "@redocly/graphql-docs": "1.12.0-next.6",
         "@redocly/mcp-typescript-sdk": "1.18.1",
-        "@redocly/openapi-core": "2.34.0",
-        "@redocly/openapi-docs": "3.23.0-next.5",
+        "@redocly/openapi-core": "2.35.0",
+        "@redocly/openapi-docs": "3.23.0-next.6",
         "@redocly/portal-legacy-ui": "0.18.0-next.0",
-        "@redocly/portal-plugin-mock-server": "0.20.0-next.5",
-        "@redocly/realm-asyncapi-sdk": "0.13.0-next.3",
-        "@redocly/theme": "0.67.0-next.4",
+        "@redocly/portal-plugin-mock-server": "0.20.0-next.6",
+        "@redocly/realm-asyncapi-sdk": "0.13.0-next.4",
+        "@redocly/theme": "0.67.0-next.5",
         "@shikijs/transformers": "3.21.0",
         "@tanstack/react-query": "5.62.3",
         "@tanstack/react-table": "8.21.3",
@@ -3163,9 +3487,9 @@
       }
     },
     "node_modules/@redocly/realm-asyncapi-sdk": {
-      "version": "0.13.0-next.3",
-      "resolved": "https://registry.npmjs.org/@redocly/realm-asyncapi-sdk/-/realm-asyncapi-sdk-0.13.0-next.3.tgz",
-      "integrity": "sha512-I1tqv5CIm6bX0K43bzI601TSmCI1adWqsRD4mnfX/PHM5k+QR4T8FucvdBFw8QqQQyYtIqwyC4OcEmgxJGpF7w==",
+      "version": "0.13.0-next.4",
+      "resolved": "https://registry.npmjs.org/@redocly/realm-asyncapi-sdk/-/realm-asyncapi-sdk-0.13.0-next.4.tgz",
+      "integrity": "sha512-pbL/CzTjdf3A6ucHl5WpT7ZvsIBlOS/3V0uGfa7Jt5Qyf0vmoGm0FwpaadtRgeZ0jQgoCTGGA2G+d2AbzgnMFQ==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "safe-stable-stringify": "2.5.0"
@@ -3187,10 +3511,136 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/@redocly/realm/node_modules/@redocly/config": {
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.49.1.tgz",
+      "integrity": "sha512-Eid8/bDcsf2bpTJ2qZhULflf6Y/TtoUFZt0+a5XZzjZj0uA8L8EQiY/nEdBd6lZQlZsnu8/cAUhTyBebnLi0gA==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "2.7.2"
+      }
+    },
+    "node_modules/@redocly/realm/node_modules/@redocly/graphql-docs": {
+      "version": "1.12.0-next.6",
+      "resolved": "https://registry.npmjs.org/@redocly/graphql-docs/-/graphql-docs-1.12.0-next.6.tgz",
+      "integrity": "sha512-Oc7H8PcIAymjtmCBzG1s+mjtT3QozEGLJYj9HO9Jhbr5XkE5s8oifnPzE77I8ym8jGqoxJj292iRXcm4wFro+g==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@redocly/config": "0.49.1",
+        "@redocly/openapi-docs": "3.23.0-next.6",
+        "@redocly/redoc-opentelemetry": "0.2.2",
+        "deepmerge": "^4.2.2",
+        "marked": "^4.0.15",
+        "web-vitals": "3.3.1"
+      },
+      "peerDependencies": {
+        "@redocly/theme": "0.67.0-next.5",
+        "graphql": "16.12.0",
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4",
+        "react-router-dom": "^6.30.3",
+        "styled-components": "^5.3.11 || ^6.0.0"
+      }
+    },
+    "node_modules/@redocly/realm/node_modules/@redocly/openapi-core": {
+      "version": "2.35.0",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.35.0.tgz",
+      "integrity": "sha512-QAMFYwPFyunIe8MD6OTKlp2NXhuRy+90LJd1iUJgtlKR1YRYIpibeHVeiKTHULT5MFMSGiw0Bcv+IRTedt9stQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/ajv": "^8.18.1",
+        "@redocly/config": "^0.49.0",
+        "ajv": "npm:@redocly/ajv@8.18.1",
+        "ajv-formats": "^3.0.1",
+        "colorette": "^1.2.0",
+        "js-levenshtein": "^1.1.6",
+        "js-yaml": "^4.2.0",
+        "picomatch": "^4.0.4",
+        "pluralize": "^8.0.0",
+        "yaml-ast-parser": "0.0.43"
+      },
+      "engines": {
+        "node": ">=22.12.0 || >=20.19.0 <21.0.0",
+        "npm": ">=10"
+      }
+    },
+    "node_modules/@redocly/realm/node_modules/@redocly/openapi-core/node_modules/@redocly/ajv": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.3.tgz",
+      "integrity": "sha512-l42u0of3hY98sN2A+M4qTX1O/KrpgGH32Hu9kP2GtHyD5Dfqq86PKFLe5dwaD8DEnNmlOlll2BAmeEtf0DaySg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@redocly/realm/node_modules/@redocly/openapi-core/node_modules/colorette": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
+      "license": "MIT"
+    },
+    "node_modules/@redocly/realm/node_modules/@redocly/openapi-core/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@redocly/realm/node_modules/@redocly/theme": {
+      "version": "0.67.0-next.5",
+      "resolved": "https://registry.npmjs.org/@redocly/theme/-/theme-0.67.0-next.5.tgz",
+      "integrity": "sha512-pCSlbXWSYWnSV34nUKYCO7K0+4995GcxzBACVK+81N/fBSMiv/2xeBavze2I/tUHzD4dLTXotvTtRqC6Xy4qmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/config": "0.49.1",
+        "@tanstack/react-query": "5.62.3",
+        "@tanstack/react-virtual": "3.13.0",
+        "@xyflow/react": "^12.8.2",
+        "copy-to-clipboard": "3.3.3",
+        "file-saver": "2.0.5",
+        "highlight-words-core": "1.2.2",
+        "hotkeys-js": "3.10.1",
+        "i18next": "22.4.15",
+        "jszip": "3.10.1",
+        "lodash.debounce": "^4.0.8",
+        "lodash.throttle": "4.1.1",
+        "nprogress": "0.2.0",
+        "openapi-sampler": "^1.7.2",
+        "react-calendar": "5.1.0",
+        "react-date-picker": "11.0.0"
+      },
+      "peerDependencies": {
+        "@markdoc/markdoc": "0.5.2",
+        "lodash.debounce": "^4.0.8",
+        "lodash.throttle": "^4.1.1",
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4",
+        "react-router-dom": "^6.30.3",
+        "styled-components": "^4.1.1 || ^5.3.11 || ^6.0.0"
+      }
+    },
     "node_modules/@redocly/realm/node_modules/colorette": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "license": "MIT"
+    },
+    "node_modules/@redocly/realm/node_modules/highlight-words-core": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/highlight-words-core/-/highlight-words-core-1.2.2.tgz",
+      "integrity": "sha512-BXUKIkUuh6cmmxzi5OIbUJxrG8OAk2MqoL1DtO3Wo9D2faJg2ph5ntyuQeLqaHJmzER6H5tllCDA9ZnNe9BVGg==",
       "license": "MIT"
     },
     "node_modules/@redocly/realm/node_modules/js-yaml": {
@@ -3215,6 +3665,32 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/@redocly/realm/node_modules/json-schema-to-ts": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-2.7.2.tgz",
+      "integrity": "sha512-R1JfqKqbBR4qE8UyBR56Ms30LL62/nlhoz+1UkfI/VE7p54Awu919FZ6ZUPG8zIa3XB65usPJgr1ONVncUGSaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@types/json-schema": "^7.0.9",
+        "ts-algebra": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@redocly/realm/node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/@redocly/realm/node_modules/picomatch": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
@@ -3227,88 +3703,80 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/@redocly/redoc-opentelemetry": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@redocly/redoc-opentelemetry/-/redoc-opentelemetry-0.2.1.tgz",
-      "integrity": "sha512-wgcQ5RiNVdIFi+XkhX4YC2wc32YkbNLM8/ARaiSMu7vEC+Nb8WEuxPbG0M1nyUisa5Mk4d8PaHMlTVu/GR2iEg==",
+    "node_modules/@redocly/realm/node_modules/ts-algebra": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-1.2.2.tgz",
+      "integrity": "sha512-kloPhf1hq3JbCPOTYoOWDKxebWjNb2o/LKnNfkWhxVVisFFmMJPPdJeGoGmM+iRLyoXAR61e08Pb+vUXINg8aA==",
       "license": "MIT"
     },
-    "node_modules/@redocly/replay": {
-      "version": "0.26.0-next.5",
-      "resolved": "https://registry.npmjs.org/@redocly/replay/-/replay-0.26.0-next.5.tgz",
-      "integrity": "sha512-a2G/vNRD+b3loM8My+U+9KOZbo2xgNBfRjNM+yp+hYYPJ+Ot/3QfMHt92d+V/FrnhuhSRvUXu7eG9uSTH5vxmA==",
+    "node_modules/@redocly/redoc-opentelemetry": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@redocly/redoc-opentelemetry/-/redoc-opentelemetry-0.2.2.tgz",
+      "integrity": "sha512-gp9rkjtTfEMLNzph+7/7pnOtEjkjvz7dC5A10XQjzKDjqEJ9E55p14kvk1iFgpsztQFVQsYXMMdB1vGmU4/hBg==",
+      "license": "MIT"
+    },
+    "node_modules/@redocly/respect-core": {
+      "version": "2.35.0",
+      "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-2.35.0.tgz",
+      "integrity": "sha512-p7X6cgmRUYk7DJWDZHSFciOtz9koc9XEOg1kmowUKwqkzkjGtS3mggDmX3/xSZEtbhXEPqU8mBzRFBzKoLiAPA==",
+      "license": "MIT",
       "dependencies": {
-        "@ai-sdk/anthropic": "3.0.1",
-        "@ai-sdk/google": "3.0.1",
-        "@ai-sdk/openai": "3.0.1",
-        "@ai-sdk/provider": "3.0.0",
-        "@ai-sdk/react": "3.0.118",
-        "@codemirror/autocomplete": "^6.15.0",
-        "@codemirror/commands": "^6.9.0",
-        "@codemirror/lang-html": "^6.4.7",
-        "@codemirror/lang-java": "^6.0.2",
-        "@codemirror/lang-javascript": "^6.2.4",
-        "@codemirror/lang-json": "^6.0.1",
-        "@codemirror/lang-python": "^6.2.1",
-        "@codemirror/lang-xml": "^6.0.2",
-        "@codemirror/lang-yaml": "^6.1.2",
-        "@codemirror/language": "^6.11.3",
-        "@codemirror/legacy-modes": "^6.5.2",
-        "@codemirror/lint": "^6.5.0",
-        "@codemirror/search": "^6.5.11",
-        "@codemirror/state": "^6.5.2",
-        "@codemirror/view": "^6.25.1",
-        "@dnd-kit/core": "^6.1.0",
-        "@dnd-kit/sortable": "^8.0.0",
-        "@dnd-kit/utilities": "^3.2.2",
-        "@lezer/highlight": "^1.1.6",
+        "@faker-js/faker": "^7.6.0",
         "@noble/hashes": "^1.8.0",
-        "@opentelemetry/api": "1.9.0",
-        "@redocly/hookstate-core": "^4.2.4",
-        "@redocly/hookstate-devtools": "^4.2.1",
-        "@redocly/openapi-core": "2.34.0",
-        "@redocly/respect-core": "2.34.0",
-        "@redocly/vscode-json-languageservice": "^3.4.9",
-        "@tauri-apps/api": "2.4.1",
-        "@tauri-apps/plugin-dialog": "2.0.0-rc.1",
-        "@tauri-apps/plugin-fs": "2.0.0-rc.2",
-        "@tauri-apps/plugin-opener": "^2.5.2",
-        "@uiw/codemirror-theme-material": "^4.21.20",
-        "@uiw/react-codemirror": "^4.21.20",
-        "ai": "6.0.111",
-        "dayjs": "^1.11.7",
-        "drizzle-orm": "^0.45.0",
-        "fast-xml-parser": "5.7.3",
-        "idb": "^8.0.2",
-        "js-yaml": "4.2.0",
+        "@redocly/ajv": "^8.18.1",
+        "@redocly/openapi-core": "2.35.0",
+        "ajv": "npm:@redocly/ajv@8.18.1",
+        "better-ajv-errors": "^2.0.3",
+        "colorette": "^2.0.20",
         "json-pointer": "^0.6.2",
-        "json-schema-typed": "^8.0.1",
-        "marked": "^4.0.15",
-        "p-queue": "^7.3.4",
-        "path-browserify": "^1.0.1",
-        "rc-tooltip": "^6.1.3",
-        "react-arborist": "3.4.0",
-        "react-resizable-panels": "^3.0.6",
-        "react-select": "5.10.1",
-        "shellwords": "^1.1.1",
-        "ulid": "^2.3.0",
-        "usehooks-ts": "^3.1.1",
-        "yaml": "^2.0.0",
-        "zod": "^3.25.76"
+        "jsonpath-rfc9535": "1.3.0",
+        "openapi-sampler": "^1.7.1",
+        "outdent": "^0.8.0",
+        "picomatch": "^4.0.4"
       },
-      "peerDependencies": {
-        "@redocly/theme": "0.67.0-next.4",
-        "@tanstack/react-query": "5.62.3",
-        "react": "^19.2.4",
-        "react-dom": "^19.2.4",
-        "react-router-dom": "^6.30.3",
-        "styled-components": "^6.4.2"
+      "engines": {
+        "node": ">=22.12.0 || >=20.19.0 <21.0.0",
+        "npm": ">=10"
       }
     },
-    "node_modules/@redocly/replay/node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+    "node_modules/@redocly/respect-core/node_modules/@redocly/openapi-core": {
+      "version": "2.35.0",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.35.0.tgz",
+      "integrity": "sha512-QAMFYwPFyunIe8MD6OTKlp2NXhuRy+90LJd1iUJgtlKR1YRYIpibeHVeiKTHULT5MFMSGiw0Bcv+IRTedt9stQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/ajv": "^8.18.1",
+        "@redocly/config": "^0.49.0",
+        "ajv": "npm:@redocly/ajv@8.18.1",
+        "ajv-formats": "^3.0.1",
+        "colorette": "^1.2.0",
+        "js-levenshtein": "^1.1.6",
+        "js-yaml": "^4.2.0",
+        "picomatch": "^4.0.4",
+        "pluralize": "^8.0.0",
+        "yaml-ast-parser": "0.0.43"
+      },
+      "engines": {
+        "node": ">=22.12.0 || >=20.19.0 <21.0.0",
+        "npm": ">=10"
+      }
+    },
+    "node_modules/@redocly/respect-core/node_modules/@redocly/openapi-core/node_modules/colorette": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
+      "license": "MIT"
+    },
+    "node_modules/@redocly/respect-core/node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "license": "MIT"
+    },
+    "node_modules/@redocly/respect-core/node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",
@@ -3327,53 +3795,12 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/@redocly/replay/node_modules/marked": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/@redocly/respect-core": {
-      "version": "2.34.0",
-      "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-2.34.0.tgz",
-      "integrity": "sha512-h3flGJdUk0c7n8PbjK0ZLhZbPHjkkF3gA4CMYBxGSo6fuvDJcCGVHe/EV6hZrq7N3XWUG2S+zTKwBQfVhOWq2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@faker-js/faker": "^7.6.0",
-        "@noble/hashes": "^1.8.0",
-        "@redocly/ajv": "^8.18.1",
-        "@redocly/openapi-core": "2.34.0",
-        "ajv": "npm:@redocly/ajv@8.18.1",
-        "better-ajv-errors": "^2.0.3",
-        "colorette": "^2.0.20",
-        "json-pointer": "^0.6.2",
-        "jsonpath-rfc9535": "1.3.0",
-        "openapi-sampler": "^1.7.1",
-        "outdent": "^0.8.0",
-        "picomatch": "^4.0.4"
-      },
-      "engines": {
-        "node": ">=22.12.0 || >=20.19.0 <21.0.0",
-        "npm": ">=10"
-      }
-    },
-    "node_modules/@redocly/respect-core/node_modules/colorette": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-      "license": "MIT"
-    },
     "node_modules/@redocly/theme": {
       "version": "0.67.0-next.4",
       "resolved": "https://registry.npmjs.org/@redocly/theme/-/theme-0.67.0-next.4.tgz",
       "integrity": "sha512-/TqH4H9LgifbWz/KDp1mFwQ6Ue5FZtOlP2fO0sO7m/C7zx5ZzzMGqW6xdu/3J4GYw1yciJIn6qrW0/hbZaGBeA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@redocly/config": "0.49.0",
         "@tanstack/react-query": "5.62.3",
@@ -3406,7 +3833,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/highlight-words-core/-/highlight-words-core-1.2.2.tgz",
       "integrity": "sha512-BXUKIkUuh6cmmxzi5OIbUJxrG8OAk2MqoL1DtO3Wo9D2faJg2ph5ntyuQeLqaHJmzER6H5tllCDA9ZnNe9BVGg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@redocly/vscode-json-languageservice": {
       "version": "3.4.9",
@@ -5203,15 +5631,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/cosmiconfig/node_modules/yaml": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -5228,7 +5647,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -7044,9 +7463,9 @@
       "license": "MIT"
     },
     "node_modules/immutable": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.8.tgz",
-      "integrity": "sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==",
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.9.tgz",
+      "integrity": "sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==",
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -7361,7 +7780,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/jotai": {
@@ -7406,9 +7825,9 @@
       }
     },
     "node_modules/js-base64": {
-      "version": "3.7.8",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
-      "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.8.0.tgz",
+      "integrity": "sha512-65kvbemyZhj+ExQt1PEFyBEjL5vAHysu1lJdW1AwhhChkO8ZBPizYk/m9GVrpbS2Je1hF+UYZ+6KywqtZV8mHw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/js-cookie": {
@@ -8531,7 +8950,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -8545,7 +8964,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -8748,15 +9167,6 @@
         "url": "https://github.com/Mermade/oas-kit?sponsor=1"
       }
     },
-    "node_modules/oas-linter/node_modules/yaml": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/oas-resolver": {
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/oas-resolver/-/oas-resolver-2.5.6.tgz",
@@ -8774,15 +9184,6 @@
       },
       "funding": {
         "url": "https://github.com/Mermade/oas-kit?sponsor=1"
-      }
-    },
-    "node_modules/oas-resolver/node_modules/yaml": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/oas-schema-walker": {
@@ -8811,15 +9212,6 @@
       },
       "funding": {
         "url": "https://github.com/Mermade/oas-kit?sponsor=1"
-      }
-    },
-    "node_modules/oas-validator/node_modules/yaml": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/object-assign": {
@@ -9086,7 +9478,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10211,7 +10603,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -10224,7 +10616,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10752,15 +11144,6 @@
       },
       "funding": {
         "url": "https://github.com/Mermade/oas-kit?sponsor=1"
-      }
-    },
-    "node_modules/swagger2openapi/node_modules/yaml": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/swr": {
@@ -11359,7 +11742,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -11548,18 +11931,12 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
       "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
+        "node": ">= 6"
       }
     },
     "node_modules/yaml-ast-parser": {
@@ -11569,9 +11946,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "UNLICENSED",
       "dependencies": {
-        "@redocly/marketing-pages": "0.2.5",
+        "@redocly/marketing-pages": "0.2.8",
         "@redocly/realm": "0.135.0-next.6",
         "buffer": "^6.0.3",
         "highlight-words-core": "^1.2.3",
@@ -538,13 +538,13 @@
       }
     },
     "node_modules/@codemirror/commands": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
-      "integrity": "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==",
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.4.tgz",
+      "integrity": "sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.6.0",
+        "@codemirror/state": "^6.7.0",
         "@codemirror/view": "^6.27.0",
         "@lezer/common": "^1.1.0"
       }
@@ -657,9 +657,9 @@
       }
     },
     "node_modules/@codemirror/language": {
-      "version": "6.12.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
-      "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.4.tgz",
+      "integrity": "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
@@ -680,9 +680,9 @@
       }
     },
     "node_modules/@codemirror/lint": {
-      "version": "6.9.6",
-      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.6.tgz",
-      "integrity": "sha512-6Kp7r6XfCi/D/5sdXieMfg9pJU1bUEx96WITuLU6ESaKizCz0QHFMjY/TaFSbigDdEAIgi93itLBIUETP4oK+A==",
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.7.tgz",
+      "integrity": "sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
@@ -691,9 +691,9 @@
       }
     },
     "node_modules/@codemirror/search": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.7.0.tgz",
-      "integrity": "sha512-ZvGm99wc/s2cITtMT15LFdn8aH/aS+V+DqyGq/N5ZlV5vWtH+nILvC2nw0zX7ByNoHHDZ2IxxdW38O0tc5nVHg==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.7.1.tgz",
+      "integrity": "sha512-uMe5UO6PamJtSHrXhhHOzSX3ReWtiJrva6GnPMwSOrZtiExb5X5eExhr2OUZQVvdxPsKpY3Ro2mFbQadpPWmHA==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
@@ -702,9 +702,9 @@
       }
     },
     "node_modules/@codemirror/state": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
-      "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.0.tgz",
+      "integrity": "sha512-Zbl9NyscLMZkfXPQnNAIIAFftidrA1UbcJEIMp24C0Bukc2I5T8wJS0wsXYsnDOqCFJUeJ1BITGNs5CqPDSmSg==",
       "license": "MIT",
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
@@ -723,12 +723,12 @@
       }
     },
     "node_modules/@codemirror/view": {
-      "version": "6.43.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.0.tgz",
-      "integrity": "sha512-V7ZCLQO3Jus9hzh2jVCCPW3mO4IBMr43O37PqSUYautJSnnJF41YlgLw21x0fLJTYvJ+Vkm6Gp+qKGH9pltgXA==",
+      "version": "6.43.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.4.tgz",
+      "integrity": "sha512-YImu23iyKfncJzT7sRy+rEqEhSc8RhOHqDxwy4WzXRKJwYm6iwf/9OJk5ctCAdZ6yi2ZqaGEvmf55fSVqMDrgg==",
       "license": "MIT",
       "dependencies": {
-        "@codemirror/state": "^6.6.0",
+        "@codemirror/state": "^6.7.0",
         "crelt": "^1.0.6",
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
@@ -2074,9 +2074,9 @@
       ]
     },
     "node_modules/@marijn/find-cluster-break": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
-      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz",
+      "integrity": "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==",
       "license": "MIT"
     },
     "node_modules/@markdoc/markdoc": {
@@ -2643,78 +2643,10 @@
         "react": "^19.2.4"
       }
     },
-    "node_modules/@redocly/asyncapi-docs/node_modules/@redocly/config": {
+    "node_modules/@redocly/config": {
       "version": "0.49.1",
       "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.49.1.tgz",
       "integrity": "sha512-Eid8/bDcsf2bpTJ2qZhULflf6Y/TtoUFZt0+a5XZzjZj0uA8L8EQiY/nEdBd6lZQlZsnu8/cAUhTyBebnLi0gA==",
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "2.7.2"
-      }
-    },
-    "node_modules/@redocly/asyncapi-docs/node_modules/@redocly/theme": {
-      "version": "0.67.0-next.5",
-      "resolved": "https://registry.npmjs.org/@redocly/theme/-/theme-0.67.0-next.5.tgz",
-      "integrity": "sha512-pCSlbXWSYWnSV34nUKYCO7K0+4995GcxzBACVK+81N/fBSMiv/2xeBavze2I/tUHzD4dLTXotvTtRqC6Xy4qmA==",
-      "license": "MIT",
-      "dependencies": {
-        "@redocly/config": "0.49.1",
-        "@tanstack/react-query": "5.62.3",
-        "@tanstack/react-virtual": "3.13.0",
-        "@xyflow/react": "^12.8.2",
-        "copy-to-clipboard": "3.3.3",
-        "file-saver": "2.0.5",
-        "highlight-words-core": "1.2.2",
-        "hotkeys-js": "3.10.1",
-        "i18next": "22.4.15",
-        "jszip": "3.10.1",
-        "lodash.debounce": "^4.0.8",
-        "lodash.throttle": "4.1.1",
-        "nprogress": "0.2.0",
-        "openapi-sampler": "^1.7.2",
-        "react-calendar": "5.1.0",
-        "react-date-picker": "11.0.0"
-      },
-      "peerDependencies": {
-        "@markdoc/markdoc": "0.5.2",
-        "lodash.debounce": "^4.0.8",
-        "lodash.throttle": "^4.1.1",
-        "react": "^19.2.4",
-        "react-dom": "^19.2.4",
-        "react-router-dom": "^6.30.3",
-        "styled-components": "^4.1.1 || ^5.3.11 || ^6.0.0"
-      }
-    },
-    "node_modules/@redocly/asyncapi-docs/node_modules/highlight-words-core": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/highlight-words-core/-/highlight-words-core-1.2.2.tgz",
-      "integrity": "sha512-BXUKIkUuh6cmmxzi5OIbUJxrG8OAk2MqoL1DtO3Wo9D2faJg2ph5ntyuQeLqaHJmzER6H5tllCDA9ZnNe9BVGg==",
-      "license": "MIT"
-    },
-    "node_modules/@redocly/asyncapi-docs/node_modules/json-schema-to-ts": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-2.7.2.tgz",
-      "integrity": "sha512-R1JfqKqbBR4qE8UyBR56Ms30LL62/nlhoz+1UkfI/VE7p54Awu919FZ6ZUPG8zIa3XB65usPJgr1ONVncUGSaQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "@types/json-schema": "^7.0.9",
-        "ts-algebra": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@redocly/asyncapi-docs/node_modules/ts-algebra": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-1.2.2.tgz",
-      "integrity": "sha512-kloPhf1hq3JbCPOTYoOWDKxebWjNb2o/LKnNfkWhxVVisFFmMJPPdJeGoGmM+iRLyoXAR61e08Pb+vUXINg8aA==",
-      "license": "MIT"
-    },
-    "node_modules/@redocly/config": {
-      "version": "0.49.0",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.49.0.tgz",
-      "integrity": "sha512-OI/rpEffX3fKUuy+OuBHPRspRI/S30b9aiqxfZLMpSWZzDncEGPxSEP1O2LrBVshnDX4hLjVjLvCZ4YT85+1rw==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "2.7.2"
@@ -2739,6 +2671,40 @@
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-1.2.2.tgz",
       "integrity": "sha512-kloPhf1hq3JbCPOTYoOWDKxebWjNb2o/LKnNfkWhxVVisFFmMJPPdJeGoGmM+iRLyoXAR61e08Pb+vUXINg8aA==",
       "license": "MIT"
+    },
+    "node_modules/@redocly/graphql-docs": {
+      "version": "1.12.0-next.6",
+      "resolved": "https://registry.npmjs.org/@redocly/graphql-docs/-/graphql-docs-1.12.0-next.6.tgz",
+      "integrity": "sha512-Oc7H8PcIAymjtmCBzG1s+mjtT3QozEGLJYj9HO9Jhbr5XkE5s8oifnPzE77I8ym8jGqoxJj292iRXcm4wFro+g==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@redocly/config": "0.49.1",
+        "@redocly/openapi-docs": "3.23.0-next.6",
+        "@redocly/redoc-opentelemetry": "0.2.2",
+        "deepmerge": "^4.2.2",
+        "marked": "^4.0.15",
+        "web-vitals": "3.3.1"
+      },
+      "peerDependencies": {
+        "@redocly/theme": "0.67.0-next.5",
+        "graphql": "16.12.0",
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4",
+        "react-router-dom": "^6.30.3",
+        "styled-components": "^5.3.11 || ^6.0.0"
+      }
+    },
+    "node_modules/@redocly/graphql-docs/node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/@redocly/hookstate-core": {
       "version": "4.2.4",
@@ -2769,9 +2735,9 @@
       "license": "SEE LICENSE IN LICENSE"
     },
     "node_modules/@redocly/marketing-pages": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@redocly/marketing-pages/-/marketing-pages-0.2.5.tgz",
-      "integrity": "sha512-HwVD5IspdMAW/V2aNyYLyS1uz5/53X8Llg6atqVTt4EQsUvnH5OG29deWeWVbGE7dRVWzjqxBATgjbg8Rc7RWw==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@redocly/marketing-pages/-/marketing-pages-0.2.8.tgz",
+      "integrity": "sha512-hBWCuwOeomri5NrSdtrvy3BrZCHdXdcTJVnQrDgzdfgULgz9izw90vUBCT9IjF77D2EllQD6kqynSY/+POwgDA==",
       "license": "UNLICENSED",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.1",
@@ -2783,7 +2749,7 @@
         "@react-spring/web": "^10.1.0",
         "@rebilly/lead-source-tracker": "^2.18.13",
         "@redocly/json-to-json-schema": "^0.0.1",
-        "@redocly/openapi-language-server": "0.9.5",
+        "@redocly/openapi-language-server": "0.9.7",
         "@uiw/react-codemirror": "^4.21.20",
         "csstype": "^3.1.2",
         "dayjs": "1.11.21",
@@ -2811,8 +2777,8 @@
         "ulid": "^2.3.0"
       },
       "peerDependencies": {
-        "@redocly/realm": "0.135.0-next.5",
-        "@redocly/theme": "0.67.0-next.4",
+        "@redocly/realm": "0.135.0-next.6",
+        "@redocly/theme": "0.67.0-next.5",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "styled-components": "^6.4.2"
@@ -2928,61 +2894,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/@redocly/mock-server/node_modules/@redocly/openapi-core": {
-      "version": "2.35.0",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.35.0.tgz",
-      "integrity": "sha512-QAMFYwPFyunIe8MD6OTKlp2NXhuRy+90LJd1iUJgtlKR1YRYIpibeHVeiKTHULT5MFMSGiw0Bcv+IRTedt9stQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@redocly/ajv": "^8.18.1",
-        "@redocly/config": "^0.49.0",
-        "ajv": "npm:@redocly/ajv@8.18.1",
-        "ajv-formats": "^3.0.1",
-        "colorette": "^1.2.0",
-        "js-levenshtein": "^1.1.6",
-        "js-yaml": "^4.2.0",
-        "picomatch": "^4.0.4",
-        "pluralize": "^8.0.0",
-        "yaml-ast-parser": "0.0.43"
-      },
-      "engines": {
-        "node": ">=22.12.0 || >=20.19.0 <21.0.0",
-        "npm": ">=10"
-      }
-    },
-    "node_modules/@redocly/mock-server/node_modules/@redocly/openapi-core/node_modules/@redocly/ajv": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.3.tgz",
-      "integrity": "sha512-l42u0of3hY98sN2A+M4qTX1O/KrpgGH32Hu9kP2GtHyD5Dfqq86PKFLe5dwaD8DEnNmlOlll2BAmeEtf0DaySg==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@redocly/mock-server/node_modules/@redocly/openapi-core/node_modules/ajv": {
-      "name": "@redocly/ajv",
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.1.tgz",
-      "integrity": "sha512-Ifm/pP/tul1qmAecpbVxCBluVE32rKfjf8gYXH4xI2gCv9mRWFhJMHzkPDM4TXlxwPQYIFegymlsy8lXz7optA==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/@redocly/mock-server/node_modules/ajv": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
@@ -3022,11 +2933,10 @@
       }
     },
     "node_modules/@redocly/openapi-core": {
-      "version": "2.34.0",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.34.0.tgz",
-      "integrity": "sha512-QHdrFT34zJLTwC1vG4QAwSzHMh2Ll545X/u5ScKzVPh8PPmjYVE+jMjVmwlRXyTPKWxOerqbPY7ZOACOCOSfbg==",
+      "version": "2.35.0",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.35.0.tgz",
+      "integrity": "sha512-QAMFYwPFyunIe8MD6OTKlp2NXhuRy+90LJd1iUJgtlKR1YRYIpibeHVeiKTHULT5MFMSGiw0Bcv+IRTedt9stQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@redocly/ajv": "^8.18.1",
         "@redocly/config": "^0.49.0",
@@ -3045,9 +2955,9 @@
       }
     },
     "node_modules/@redocly/openapi-core/node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",
@@ -3059,7 +2969,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -3107,164 +3016,32 @@
         "styled-components": "^4.1.1 || ^5.3.11 || ^6.0.0"
       }
     },
-    "node_modules/@redocly/openapi-docs/node_modules/@redocly/config": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.49.1.tgz",
-      "integrity": "sha512-Eid8/bDcsf2bpTJ2qZhULflf6Y/TtoUFZt0+a5XZzjZj0uA8L8EQiY/nEdBd6lZQlZsnu8/cAUhTyBebnLi0gA==",
+    "node_modules/@redocly/openapi-language-server": {
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-language-server/-/openapi-language-server-0.9.7.tgz",
+      "integrity": "sha512-Wv8KTnDMxJ6Sg3dLo3OrFV3ByYLRITqad1MyVWGiOyxpkQ1fgsg1EuTlwMcWb9VcWtywrpXXrZvH6Y0AgpnOEg==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@redocly/config": "0.50.0",
+        "@redocly/yaml-language-server-parser": "^0.3.0",
+        "vscode-languageserver": "^9.0.1",
+        "vscode-languageserver-textdocument": "^1.0.12",
+        "vscode-uri": "^3.1.0"
+      },
+      "peerDependencies": {
+        "@redocly/openapi-core": "2.35.0"
+      }
+    },
+    "node_modules/@redocly/openapi-language-server/node_modules/@redocly/config": {
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.50.0.tgz",
+      "integrity": "sha512-DuNKw383I/kAMNIeJJBt/EoHruvhG4HM/mDtrz2+5vksTNOnM8bR04TpjFN4do68gSIhUIMH2m5kDiffkcMn9Q==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "2.7.2"
       }
     },
-    "node_modules/@redocly/openapi-docs/node_modules/@redocly/openapi-core": {
-      "version": "2.35.0",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.35.0.tgz",
-      "integrity": "sha512-QAMFYwPFyunIe8MD6OTKlp2NXhuRy+90LJd1iUJgtlKR1YRYIpibeHVeiKTHULT5MFMSGiw0Bcv+IRTedt9stQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@redocly/ajv": "^8.18.1",
-        "@redocly/config": "^0.49.0",
-        "ajv": "npm:@redocly/ajv@8.18.1",
-        "ajv-formats": "^3.0.1",
-        "colorette": "^1.2.0",
-        "js-levenshtein": "^1.1.6",
-        "js-yaml": "^4.2.0",
-        "picomatch": "^4.0.4",
-        "pluralize": "^8.0.0",
-        "yaml-ast-parser": "0.0.43"
-      },
-      "engines": {
-        "node": ">=22.12.0 || >=20.19.0 <21.0.0",
-        "npm": ">=10"
-      }
-    },
-    "node_modules/@redocly/openapi-docs/node_modules/@redocly/replay": {
-      "version": "0.26.0-next.6",
-      "resolved": "https://registry.npmjs.org/@redocly/replay/-/replay-0.26.0-next.6.tgz",
-      "integrity": "sha512-EH7bkhCaAxgTkUh+kpdh5vpxzMEOkvRfRcyjgDh8CW8girLwgVuUvRVeJ7Z9ZEOtpK5yi+BSjFIPyk4Jt8LrSA==",
-      "dependencies": {
-        "@ai-sdk/anthropic": "3.0.1",
-        "@ai-sdk/google": "3.0.1",
-        "@ai-sdk/openai": "3.0.1",
-        "@ai-sdk/provider": "3.0.0",
-        "@ai-sdk/react": "3.0.118",
-        "@codemirror/autocomplete": "^6.15.0",
-        "@codemirror/commands": "^6.9.0",
-        "@codemirror/lang-html": "^6.4.7",
-        "@codemirror/lang-java": "^6.0.2",
-        "@codemirror/lang-javascript": "^6.2.4",
-        "@codemirror/lang-json": "^6.0.1",
-        "@codemirror/lang-python": "^6.2.1",
-        "@codemirror/lang-xml": "^6.0.2",
-        "@codemirror/lang-yaml": "^6.1.2",
-        "@codemirror/language": "^6.11.3",
-        "@codemirror/legacy-modes": "^6.5.2",
-        "@codemirror/lint": "^6.5.0",
-        "@codemirror/search": "^6.5.11",
-        "@codemirror/state": "^6.5.2",
-        "@codemirror/view": "^6.25.1",
-        "@dnd-kit/core": "^6.1.0",
-        "@dnd-kit/sortable": "^8.0.0",
-        "@dnd-kit/utilities": "^3.2.2",
-        "@lezer/highlight": "^1.1.6",
-        "@noble/hashes": "^1.8.0",
-        "@opentelemetry/api": "1.9.0",
-        "@redocly/hookstate-core": "^4.2.4",
-        "@redocly/hookstate-devtools": "^4.2.1",
-        "@redocly/openapi-core": "2.35.0",
-        "@redocly/respect-core": "2.35.0",
-        "@redocly/vscode-json-languageservice": "^3.4.9",
-        "@tauri-apps/api": "2.4.1",
-        "@tauri-apps/plugin-dialog": "2.0.0-rc.1",
-        "@tauri-apps/plugin-fs": "2.0.0-rc.2",
-        "@tauri-apps/plugin-opener": "^2.5.2",
-        "@uiw/codemirror-theme-material": "^4.21.20",
-        "@uiw/react-codemirror": "^4.21.20",
-        "ai": "6.0.111",
-        "dayjs": "1.11.21",
-        "diff": "^8.0.0",
-        "drizzle-orm": "^0.45.0",
-        "fast-xml-parser": "5.7.3",
-        "idb": "^8.0.2",
-        "js-yaml": "4.2.0",
-        "json-pointer": "^0.6.2",
-        "json-schema-typed": "^8.0.1",
-        "marked": "^4.0.15",
-        "p-queue": "^7.3.4",
-        "path-browserify": "^1.0.1",
-        "rc-tooltip": "^6.1.3",
-        "react-arborist": "3.4.0",
-        "react-resizable-panels": "^3.0.6",
-        "react-select": "5.10.1",
-        "shellwords": "^1.1.1",
-        "ulid": "^2.3.0",
-        "usehooks-ts": "^3.1.1",
-        "yaml": "^2.0.0",
-        "zod": "^3.25.76"
-      },
-      "peerDependencies": {
-        "@redocly/theme": "0.67.0-next.5",
-        "@tanstack/react-query": "5.62.3",
-        "react": "^19.2.4",
-        "react-dom": "^19.2.4",
-        "react-router-dom": "^6.30.3",
-        "styled-components": "^6.4.2"
-      }
-    },
-    "node_modules/@redocly/openapi-docs/node_modules/@redocly/replay/node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/@redocly/openapi-docs/node_modules/diff": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/@redocly/openapi-docs/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/@redocly/openapi-docs/node_modules/json-schema-to-ts": {
+    "node_modules/@redocly/openapi-language-server/node_modules/json-schema-to-ts": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-2.7.2.tgz",
       "integrity": "sha512-R1JfqKqbBR4qE8UyBR56Ms30LL62/nlhoz+1UkfI/VE7p54Awu919FZ6ZUPG8zIa3XB65usPJgr1ONVncUGSaQ==",
@@ -3278,54 +3055,11 @@
         "node": ">=16"
       }
     },
-    "node_modules/@redocly/openapi-docs/node_modules/marked": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/@redocly/openapi-docs/node_modules/ts-algebra": {
+    "node_modules/@redocly/openapi-language-server/node_modules/ts-algebra": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-1.2.2.tgz",
       "integrity": "sha512-kloPhf1hq3JbCPOTYoOWDKxebWjNb2o/LKnNfkWhxVVisFFmMJPPdJeGoGmM+iRLyoXAR61e08Pb+vUXINg8aA==",
       "license": "MIT"
-    },
-    "node_modules/@redocly/openapi-docs/node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
-    "node_modules/@redocly/openapi-language-server": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-language-server/-/openapi-language-server-0.9.5.tgz",
-      "integrity": "sha512-P5QKuUZ1aQ2QaAnVLazqL/zYBQ3T3FzkCTb1F23lmpoLbvjvPwv1hEJoAT1qgp8Pwps3hYH8F8YIIP8kMtvjOg==",
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@redocly/config": "0.49.0",
-        "@redocly/yaml-language-server-parser": "^0.3.0",
-        "vscode-languageserver": "^9.0.1",
-        "vscode-languageserver-textdocument": "^1.0.12",
-        "vscode-uri": "^3.1.0"
-      },
-      "peerDependencies": {
-        "@redocly/openapi-core": "2.34.0"
-      }
     },
     "node_modules/@redocly/portal-legacy-ui": {
       "version": "0.18.0-next.0",
@@ -3350,35 +3084,6 @@
         "@redocly/mock-server": "0.9.0-next.4",
         "@redocly/openapi-docs": "3.23.0-next.6"
       }
-    },
-    "node_modules/@redocly/portal-plugin-mock-server/node_modules/@redocly/config": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.49.1.tgz",
-      "integrity": "sha512-Eid8/bDcsf2bpTJ2qZhULflf6Y/TtoUFZt0+a5XZzjZj0uA8L8EQiY/nEdBd6lZQlZsnu8/cAUhTyBebnLi0gA==",
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "2.7.2"
-      }
-    },
-    "node_modules/@redocly/portal-plugin-mock-server/node_modules/json-schema-to-ts": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-2.7.2.tgz",
-      "integrity": "sha512-R1JfqKqbBR4qE8UyBR56Ms30LL62/nlhoz+1UkfI/VE7p54Awu919FZ6ZUPG8zIa3XB65usPJgr1ONVncUGSaQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "@types/json-schema": "^7.0.9",
-        "ts-algebra": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@redocly/portal-plugin-mock-server/node_modules/ts-algebra": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-1.2.2.tgz",
-      "integrity": "sha512-kloPhf1hq3JbCPOTYoOWDKxebWjNb2o/LKnNfkWhxVVisFFmMJPPdJeGoGmM+iRLyoXAR61e08Pb+vUXINg8aA==",
-      "license": "MIT"
     },
     "node_modules/@redocly/realm": {
       "version": "0.135.0-next.6",
@@ -3511,94 +3216,190 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/@redocly/realm/node_modules/@redocly/config": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.49.1.tgz",
-      "integrity": "sha512-Eid8/bDcsf2bpTJ2qZhULflf6Y/TtoUFZt0+a5XZzjZj0uA8L8EQiY/nEdBd6lZQlZsnu8/cAUhTyBebnLi0gA==",
+    "node_modules/@redocly/realm/node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "license": "MIT"
+    },
+    "node_modules/@redocly/realm/node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
-        "json-schema-to-ts": "2.7.2"
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/@redocly/realm/node_modules/@redocly/graphql-docs": {
-      "version": "1.12.0-next.6",
-      "resolved": "https://registry.npmjs.org/@redocly/graphql-docs/-/graphql-docs-1.12.0-next.6.tgz",
-      "integrity": "sha512-Oc7H8PcIAymjtmCBzG1s+mjtT3QozEGLJYj9HO9Jhbr5XkE5s8oifnPzE77I8ym8jGqoxJj292iRXcm4wFro+g==",
-      "license": "SEE LICENSE IN LICENSE",
+    "node_modules/@redocly/realm/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@redocly/redoc-opentelemetry": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@redocly/redoc-opentelemetry/-/redoc-opentelemetry-0.2.2.tgz",
+      "integrity": "sha512-gp9rkjtTfEMLNzph+7/7pnOtEjkjvz7dC5A10XQjzKDjqEJ9E55p14kvk1iFgpsztQFVQsYXMMdB1vGmU4/hBg==",
+      "license": "MIT"
+    },
+    "node_modules/@redocly/replay": {
+      "version": "0.26.0-next.6",
+      "resolved": "https://registry.npmjs.org/@redocly/replay/-/replay-0.26.0-next.6.tgz",
+      "integrity": "sha512-EH7bkhCaAxgTkUh+kpdh5vpxzMEOkvRfRcyjgDh8CW8girLwgVuUvRVeJ7Z9ZEOtpK5yi+BSjFIPyk4Jt8LrSA==",
       "dependencies": {
-        "@redocly/config": "0.49.1",
-        "@redocly/openapi-docs": "3.23.0-next.6",
-        "@redocly/redoc-opentelemetry": "0.2.2",
-        "deepmerge": "^4.2.2",
+        "@ai-sdk/anthropic": "3.0.1",
+        "@ai-sdk/google": "3.0.1",
+        "@ai-sdk/openai": "3.0.1",
+        "@ai-sdk/provider": "3.0.0",
+        "@ai-sdk/react": "3.0.118",
+        "@codemirror/autocomplete": "^6.15.0",
+        "@codemirror/commands": "^6.9.0",
+        "@codemirror/lang-html": "^6.4.7",
+        "@codemirror/lang-java": "^6.0.2",
+        "@codemirror/lang-javascript": "^6.2.4",
+        "@codemirror/lang-json": "^6.0.1",
+        "@codemirror/lang-python": "^6.2.1",
+        "@codemirror/lang-xml": "^6.0.2",
+        "@codemirror/lang-yaml": "^6.1.2",
+        "@codemirror/language": "^6.11.3",
+        "@codemirror/legacy-modes": "^6.5.2",
+        "@codemirror/lint": "^6.5.0",
+        "@codemirror/search": "^6.5.11",
+        "@codemirror/state": "^6.5.2",
+        "@codemirror/view": "^6.25.1",
+        "@dnd-kit/core": "^6.1.0",
+        "@dnd-kit/sortable": "^8.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
+        "@lezer/highlight": "^1.1.6",
+        "@noble/hashes": "^1.8.0",
+        "@opentelemetry/api": "1.9.0",
+        "@redocly/hookstate-core": "^4.2.4",
+        "@redocly/hookstate-devtools": "^4.2.1",
+        "@redocly/openapi-core": "2.35.0",
+        "@redocly/respect-core": "2.35.0",
+        "@redocly/vscode-json-languageservice": "^3.4.9",
+        "@tauri-apps/api": "2.4.1",
+        "@tauri-apps/plugin-dialog": "2.0.0-rc.1",
+        "@tauri-apps/plugin-fs": "2.0.0-rc.2",
+        "@tauri-apps/plugin-opener": "^2.5.2",
+        "@uiw/codemirror-theme-material": "^4.21.20",
+        "@uiw/react-codemirror": "^4.21.20",
+        "ai": "6.0.111",
+        "dayjs": "1.11.21",
+        "diff": "^8.0.0",
+        "drizzle-orm": "^0.45.0",
+        "fast-xml-parser": "5.7.3",
+        "idb": "^8.0.2",
+        "js-yaml": "4.2.0",
+        "json-pointer": "^0.6.2",
+        "json-schema-typed": "^8.0.1",
         "marked": "^4.0.15",
-        "web-vitals": "3.3.1"
+        "p-queue": "^7.3.4",
+        "path-browserify": "^1.0.1",
+        "rc-tooltip": "^6.1.3",
+        "react-arborist": "3.4.0",
+        "react-resizable-panels": "^3.0.6",
+        "react-select": "5.10.1",
+        "shellwords": "^1.1.1",
+        "ulid": "^2.3.0",
+        "usehooks-ts": "^3.1.1",
+        "yaml": "^2.0.0",
+        "zod": "^3.25.76"
       },
       "peerDependencies": {
         "@redocly/theme": "0.67.0-next.5",
-        "graphql": "16.12.0",
+        "@tanstack/react-query": "5.62.3",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-router-dom": "^6.30.3",
-        "styled-components": "^5.3.11 || ^6.0.0"
+        "styled-components": "^6.4.2"
       }
     },
-    "node_modules/@redocly/realm/node_modules/@redocly/openapi-core": {
-      "version": "2.35.0",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.35.0.tgz",
-      "integrity": "sha512-QAMFYwPFyunIe8MD6OTKlp2NXhuRy+90LJd1iUJgtlKR1YRYIpibeHVeiKTHULT5MFMSGiw0Bcv+IRTedt9stQ==",
+    "node_modules/@redocly/replay/node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@redocly/replay/node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@redocly/respect-core": {
+      "version": "2.35.0",
+      "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-2.35.0.tgz",
+      "integrity": "sha512-p7X6cgmRUYk7DJWDZHSFciOtz9koc9XEOg1kmowUKwqkzkjGtS3mggDmX3/xSZEtbhXEPqU8mBzRFBzKoLiAPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@faker-js/faker": "^7.6.0",
+        "@noble/hashes": "^1.8.0",
         "@redocly/ajv": "^8.18.1",
-        "@redocly/config": "^0.49.0",
+        "@redocly/openapi-core": "2.35.0",
         "ajv": "npm:@redocly/ajv@8.18.1",
-        "ajv-formats": "^3.0.1",
-        "colorette": "^1.2.0",
-        "js-levenshtein": "^1.1.6",
-        "js-yaml": "^4.2.0",
-        "picomatch": "^4.0.4",
-        "pluralize": "^8.0.0",
-        "yaml-ast-parser": "0.0.43"
+        "better-ajv-errors": "^2.0.3",
+        "colorette": "^2.0.20",
+        "json-pointer": "^0.6.2",
+        "jsonpath-rfc9535": "1.3.0",
+        "openapi-sampler": "^1.7.1",
+        "outdent": "^0.8.0",
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=22.12.0 || >=20.19.0 <21.0.0",
         "npm": ">=10"
       }
     },
-    "node_modules/@redocly/realm/node_modules/@redocly/openapi-core/node_modules/@redocly/ajv": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.3.tgz",
-      "integrity": "sha512-l42u0of3hY98sN2A+M4qTX1O/KrpgGH32Hu9kP2GtHyD5Dfqq86PKFLe5dwaD8DEnNmlOlll2BAmeEtf0DaySg==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@redocly/realm/node_modules/@redocly/openapi-core/node_modules/colorette": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
-      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
+    "node_modules/@redocly/respect-core/node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "license": "MIT"
     },
-    "node_modules/@redocly/realm/node_modules/@redocly/openapi-core/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/@redocly/realm/node_modules/@redocly/theme": {
+    "node_modules/@redocly/theme": {
       "version": "0.67.0-next.5",
       "resolved": "https://registry.npmjs.org/@redocly/theme/-/theme-0.67.0-next.5.tgz",
       "integrity": "sha512-pCSlbXWSYWnSV34nUKYCO7K0+4995GcxzBACVK+81N/fBSMiv/2xeBavze2I/tUHzD4dLTXotvTtRqC6Xy4qmA==",
@@ -3631,210 +3432,11 @@
         "styled-components": "^4.1.1 || ^5.3.11 || ^6.0.0"
       }
     },
-    "node_modules/@redocly/realm/node_modules/colorette": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-      "license": "MIT"
-    },
-    "node_modules/@redocly/realm/node_modules/highlight-words-core": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/highlight-words-core/-/highlight-words-core-1.2.2.tgz",
-      "integrity": "sha512-BXUKIkUuh6cmmxzi5OIbUJxrG8OAk2MqoL1DtO3Wo9D2faJg2ph5ntyuQeLqaHJmzER6H5tllCDA9ZnNe9BVGg==",
-      "license": "MIT"
-    },
-    "node_modules/@redocly/realm/node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/@redocly/realm/node_modules/json-schema-to-ts": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-2.7.2.tgz",
-      "integrity": "sha512-R1JfqKqbBR4qE8UyBR56Ms30LL62/nlhoz+1UkfI/VE7p54Awu919FZ6ZUPG8zIa3XB65usPJgr1ONVncUGSaQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "@types/json-schema": "^7.0.9",
-        "ts-algebra": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@redocly/realm/node_modules/marked": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/@redocly/realm/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/@redocly/realm/node_modules/ts-algebra": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-1.2.2.tgz",
-      "integrity": "sha512-kloPhf1hq3JbCPOTYoOWDKxebWjNb2o/LKnNfkWhxVVisFFmMJPPdJeGoGmM+iRLyoXAR61e08Pb+vUXINg8aA==",
-      "license": "MIT"
-    },
-    "node_modules/@redocly/redoc-opentelemetry": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@redocly/redoc-opentelemetry/-/redoc-opentelemetry-0.2.2.tgz",
-      "integrity": "sha512-gp9rkjtTfEMLNzph+7/7pnOtEjkjvz7dC5A10XQjzKDjqEJ9E55p14kvk1iFgpsztQFVQsYXMMdB1vGmU4/hBg==",
-      "license": "MIT"
-    },
-    "node_modules/@redocly/respect-core": {
-      "version": "2.35.0",
-      "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-2.35.0.tgz",
-      "integrity": "sha512-p7X6cgmRUYk7DJWDZHSFciOtz9koc9XEOg1kmowUKwqkzkjGtS3mggDmX3/xSZEtbhXEPqU8mBzRFBzKoLiAPA==",
-      "license": "MIT",
-      "dependencies": {
-        "@faker-js/faker": "^7.6.0",
-        "@noble/hashes": "^1.8.0",
-        "@redocly/ajv": "^8.18.1",
-        "@redocly/openapi-core": "2.35.0",
-        "ajv": "npm:@redocly/ajv@8.18.1",
-        "better-ajv-errors": "^2.0.3",
-        "colorette": "^2.0.20",
-        "json-pointer": "^0.6.2",
-        "jsonpath-rfc9535": "1.3.0",
-        "openapi-sampler": "^1.7.1",
-        "outdent": "^0.8.0",
-        "picomatch": "^4.0.4"
-      },
-      "engines": {
-        "node": ">=22.12.0 || >=20.19.0 <21.0.0",
-        "npm": ">=10"
-      }
-    },
-    "node_modules/@redocly/respect-core/node_modules/@redocly/openapi-core": {
-      "version": "2.35.0",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.35.0.tgz",
-      "integrity": "sha512-QAMFYwPFyunIe8MD6OTKlp2NXhuRy+90LJd1iUJgtlKR1YRYIpibeHVeiKTHULT5MFMSGiw0Bcv+IRTedt9stQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@redocly/ajv": "^8.18.1",
-        "@redocly/config": "^0.49.0",
-        "ajv": "npm:@redocly/ajv@8.18.1",
-        "ajv-formats": "^3.0.1",
-        "colorette": "^1.2.0",
-        "js-levenshtein": "^1.1.6",
-        "js-yaml": "^4.2.0",
-        "picomatch": "^4.0.4",
-        "pluralize": "^8.0.0",
-        "yaml-ast-parser": "0.0.43"
-      },
-      "engines": {
-        "node": ">=22.12.0 || >=20.19.0 <21.0.0",
-        "npm": ">=10"
-      }
-    },
-    "node_modules/@redocly/respect-core/node_modules/@redocly/openapi-core/node_modules/colorette": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
-      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
-      "license": "MIT"
-    },
-    "node_modules/@redocly/respect-core/node_modules/colorette": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-      "license": "MIT"
-    },
-    "node_modules/@redocly/respect-core/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/@redocly/theme": {
-      "version": "0.67.0-next.4",
-      "resolved": "https://registry.npmjs.org/@redocly/theme/-/theme-0.67.0-next.4.tgz",
-      "integrity": "sha512-/TqH4H9LgifbWz/KDp1mFwQ6Ue5FZtOlP2fO0sO7m/C7zx5ZzzMGqW6xdu/3J4GYw1yciJIn6qrW0/hbZaGBeA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@redocly/config": "0.49.0",
-        "@tanstack/react-query": "5.62.3",
-        "@tanstack/react-virtual": "3.13.0",
-        "@xyflow/react": "^12.8.2",
-        "copy-to-clipboard": "3.3.3",
-        "file-saver": "2.0.5",
-        "highlight-words-core": "1.2.2",
-        "hotkeys-js": "3.10.1",
-        "i18next": "22.4.15",
-        "jszip": "3.10.1",
-        "lodash.debounce": "^4.0.8",
-        "lodash.throttle": "4.1.1",
-        "nprogress": "0.2.0",
-        "openapi-sampler": "^1.7.2",
-        "react-calendar": "5.1.0",
-        "react-date-picker": "11.0.0"
-      },
-      "peerDependencies": {
-        "@markdoc/markdoc": "0.5.2",
-        "lodash.debounce": "^4.0.8",
-        "lodash.throttle": "^4.1.1",
-        "react": "^19.2.4",
-        "react-dom": "^19.2.4",
-        "react-router-dom": "^6.30.3",
-        "styled-components": "^4.1.1 || ^5.3.11 || ^6.0.0"
-      }
-    },
     "node_modules/@redocly/theme/node_modules/highlight-words-core": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/highlight-words-core/-/highlight-words-core-1.2.2.tgz",
       "integrity": "sha512-BXUKIkUuh6cmmxzi5OIbUJxrG8OAk2MqoL1DtO3Wo9D2faJg2ph5ntyuQeLqaHJmzER6H5tllCDA9ZnNe9BVGg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@redocly/vscode-json-languageservice": {
       "version": "3.4.9",
@@ -4407,12 +4009,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.7.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.7.0.tgz",
-      "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
+      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.21.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/pako": {
@@ -4739,6 +4341,18 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ai": {
       "version": "6.0.111",
       "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.111.tgz",
@@ -4930,40 +4544,15 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
-      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
-      }
-    },
-    "node_modules/axios/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/axios/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/babel-plugin-macros": {
@@ -5090,9 +4679,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.33",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.33.tgz",
-      "integrity": "sha512-bA6+tcSLpz2tIEdDXZPpPTIuxBcC4+w6SieaYyfigIa4h8GlFxbA17v22Vx3JUtuZQj9SgOsnbK+aTBzyDyEuw==",
+      "version": "2.10.40",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
+      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -5133,9 +4722,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -5157,9 +4746,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
       "funding": [
         {
           "type": "opencollective",
@@ -5176,10 +4765,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
         "update-browserslist-db": "^1.2.3"
       },
       "bin": {
@@ -5300,9 +4889,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001793",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
-      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+      "version": "1.0.30001800",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
+      "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
       "funding": [
         {
           "type": "opencollective",
@@ -5631,6 +5220,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -5638,9 +5236,9 @@
       "license": "MIT"
     },
     "node_modules/crelt": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
-      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
+      "integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -5927,9 +5525,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
-      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -6185,9 +5783,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.367",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.367.tgz",
-      "integrity": "sha512-4Mk/mrynCNQ+atY40D3UpmhLWB6AHMbYMlIrPhHcMF6x0L7O0b052FCAsxw1LlaR++UFuNg3D/A6XCuGDa0guQ==",
+      "version": "1.5.384",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.384.tgz",
+      "integrity": "sha512-g6KAKY1vkYsADvSPWvdJsuYT0ixdcu6lUtD9P/wJKGBEDlZVXh2AX42j1mPqqaQPDluWjara9ziQ7xqAeXCt5A==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -6649,9 +6247,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "funding": [
         {
           "type": "github",
@@ -6847,40 +6445,19 @@
       "license": "MIT"
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/form-data/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/form-data/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/forwarded-parse": {
@@ -7380,6 +6957,19 @@
       "resolved": "https://registry.npmjs.org/http2-client/-/http2-client-1.3.5.tgz",
       "integrity": "sha512-EC2utToWl4RKfs5zd36Mxq7nzHHBuomZboI0yYL6Y0RmBgT7Sgkq4rQ0ezFTYoIsSs7Tm9SJe+o2FcAg6GBhGA==",
       "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/i18next": {
       "version": "22.4.15",
@@ -8973,6 +8563,27 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mimic-fn": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
@@ -9121,9 +8732,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.47",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
-      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -9167,6 +8778,15 @@
         "url": "https://github.com/Mermade/oas-kit?sponsor=1"
       }
     },
+    "node_modules/oas-linter/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/oas-resolver": {
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/oas-resolver/-/oas-resolver-2.5.6.tgz",
@@ -9184,6 +8804,15 @@
       },
       "funding": {
         "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/oas-resolver/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/oas-schema-walker": {
@@ -9212,6 +8841,15 @@
       },
       "funding": {
         "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/oas-validator/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/object-assign": {
@@ -11146,6 +10784,15 @@
         "url": "https://github.com/Mermade/oas-kit?sponsor=1"
       }
     },
+    "node_modules/swagger2openapi/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/swr": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.2.tgz",
@@ -11294,6 +10941,15 @@
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "license": "MIT"
     },
+    "node_modules/ts-node/node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -11380,9 +11036,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.21.0.tgz",
-      "integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -11931,12 +11587,18 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yaml-ast-parser": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "UNLICENSED",
       "dependencies": {
-        "@redocly/marketing-pages": "0.2.8",
+        "@redocly/marketing-pages": "0.2.9",
         "@redocly/realm": "0.135.0-next.6",
         "buffer": "^6.0.3",
         "highlight-words-core": "^1.2.3",
@@ -2735,9 +2735,9 @@
       "license": "SEE LICENSE IN LICENSE"
     },
     "node_modules/@redocly/marketing-pages": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@redocly/marketing-pages/-/marketing-pages-0.2.8.tgz",
-      "integrity": "sha512-hBWCuwOeomri5NrSdtrvy3BrZCHdXdcTJVnQrDgzdfgULgz9izw90vUBCT9IjF77D2EllQD6kqynSY/+POwgDA==",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@redocly/marketing-pages/-/marketing-pages-0.2.9.tgz",
+      "integrity": "sha512-Yn3E2m+qX/3igkmgpl7wPZGDLHiplkq+b+9OtP+xxLfs1DjB/zVwK/XgTXOcLHTmrbOiOO0E5HHRr8qVqJ1p2A==",
       "license": "UNLICENSED",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "team@redocly.com",
   "license": "UNLICENSED",
   "dependencies": {
-    "@redocly/marketing-pages": "0.2.8",
+    "@redocly/marketing-pages": "0.2.9",
     "@redocly/realm": "0.135.0-next.6",
     "buffer": "^6.0.3",
     "highlight-words-core": "^1.2.3",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "UNLICENSED",
   "dependencies": {
     "@redocly/marketing-pages": "0.2.5",
-    "@redocly/realm": "0.135.0-next.5",
+    "@redocly/realm": "0.135.0-next.6",
     "buffer": "^6.0.3",
     "highlight-words-core": "^1.2.3",
     "path": "^0.12.7",
@@ -35,6 +35,6 @@
     "react-dom": "19.2.4",
     "shell-quote@<1.8.4": "1.8.4",
     "js-cookie@<3.0.7": "3.0.7",
-    "@redocly/realm": "0.135.0-next.5"
+    "@redocly/realm": "0.135.0-next.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "team@redocly.com",
   "license": "UNLICENSED",
   "dependencies": {
-    "@redocly/marketing-pages": "0.2.5",
+    "@redocly/marketing-pages": "0.2.8",
     "@redocly/realm": "0.135.0-next.6",
     "buffer": "^6.0.3",
     "highlight-words-core": "^1.2.3",


### PR DESCRIPTION
## What/Why/How?
Bump `realm` version to `v0.135.0-next.6`
Bump `marketing-pages` version to `v0.2.9`

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
