### PR TITLE
docs(other): cookie notice — rls cookie lifetime 45 to 180 days

### DIFF
--- a/pages/legal/cookie-notice-2025-09-25.md
+++ b/pages/legal/cookie-notice-2025-09-25.md
@@ -1,7 +1,7 @@
 ---
 seo:
   title: Cookie Notice
-slug: /cookie-notice
+slug: /cookie-notice-2025-09-25
 markdown:
     toc:
         hide: true
@@ -10,7 +10,7 @@ disableLastModified: true
 
 
 # Cookie Notice
-**Last updated: August 9, 2026**
+**Last updated: September 25, 2025**
 
 This Cookie Notice explains how Redocly Inc. and its group companies ("Redocly", "we", "us", and "ours") use cookies and similar technologies to recognize you when you visit, interact with or use any of our websites (such as redocly.com), online advertisements, or marketing communications (collectively for the purposes of this Notice, the "Websites"). It explains what these technologies are and why we use them, as well as your rights to control our use of them.
 
@@ -90,7 +90,7 @@ The specific types of first and third party cookies served through our Websites 
 ---
 
 - **Marketing tracking cookies:** These cookies help us track the source of leads and understand how users found our website.
-- **Redocly** - rls cookie (180 days)
+- **Redocly** - rls cookie (45 days)
 - To refuse these cookies, please follow the instructions below under the heading "How can I control cookies?"
 
 {% /table %}


### PR DESCRIPTION
## What/Why/How?

- Archived the current cookie notice as `pages/legal/cookie-notice-2025-09-25.md`, per the versioning convention (see `cookie-notice-2021-07-18.md`).
- Updated `pages/legal/cookie-notice.md`: the `rls` marketing cookie lifetime changes from 45 days to 180 days, and the "Last updated" date moves to August 9, 2026.
- One deviation from the 2021 example: the archive copy gets its own slug (`/cookie-notice-2025-09-25`). The 2021 archive kept `slug: /cookie-notice` and is unreachable today (its URL returns 404), and a third file with the same slug risks changing which page wins the live route.

Why: the Reunite change [Redocly/redocly#25902](https://github.com/Redocly/redocly/pull/25902) extends the `rls` cookie to 180 days for lead source attribution ([#25887](https://github.com/Redocly/redocly/issues/25887)). The public notice must state the real lifetime no later than the day that change deploys. This PR must merge before or with it.

## Reference

- https://github.com/Redocly/redocly/issues/25887
- https://github.com/Redocly/redocly/pull/25902 (the gated commit is `8151523c44c`)

## Testing

- Content-only change: one number and one date in the live notice, plus a frozen copy of the prior version.
- Verified the current live page states "rls cookie (45 days)" and "Last updated: September 25, 2025".

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

🤖 Generated with [Claude Code](https://claude.com/claude-code)
