### PR TITLE
chore: bump realm and marketing-pages versions

### DIFF
--- a/@theme/blog.page.tsx
+++ b/@theme/blog.page.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Route, Routes as DomRoutes, useParams } from 'react-router-dom';
+import { Route, Routes as DomRoutes, useParams } from 'react-router';
 import { PageLayout } from '@redocly/theme/layouts/PageLayout';
 import { useThemeHooks } from '@redocly/theme/core/hooks';
 

--- a/@theme/components/Footer/Footer.tsx
+++ b/@theme/components/Footer/Footer.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { linearGradient } from 'polished';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import type { ResolvedNavItem } from '@redocly/config';
 

--- a/@theme/components/Menu/MenuMobile.tsx
+++ b/@theme/components/Menu/MenuMobile.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import styled from 'styled-components';
 
 import { breakpoints } from '@redocly/theme/core/utils';

--- a/@theme/components/Navbar/Navbar.tsx
+++ b/@theme/components/Navbar/Navbar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled, { css } from 'styled-components';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import type { ResolvedConfigLinks } from '@redocly/config';
 

--- a/@theme/components/Navbar/NavbarItem.tsx
+++ b/@theme/components/Navbar/NavbarItem.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled, { css } from 'styled-components';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import type { ResolvedNavItem, ResolvedNavLinkItem, ResolvedNavGroupItem } from '@redocly/config';
 

--- a/@theme/layouts/RootLayout.tsx
+++ b/@theme/layouts/RootLayout.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import type { JSX } from 'react';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "license": "UNLICENSED",
       "dependencies": {
-        "@redocly/marketing-pages": "0.2.22",
-        "@redocly/realm": "0.136.0-next.10",
+        "@redocly/marketing-pages": "^0.2.23",
+        "@redocly/realm": "0.136.0-next.13",
         "buffer": "^6.0.3",
         "highlight-words-core": "^1.2.3",
         "path": "^0.12.7",
@@ -2146,18 +2146,18 @@
       }
     },
     "node_modules/@redocly/api-docs": {
-      "version": "0.1.0-next.2",
-      "resolved": "https://registry.npmjs.org/@redocly/api-docs/-/api-docs-0.1.0-next.2.tgz",
-      "integrity": "sha512-P812wFgMyDaZPlMlgNOb4VBX0uBVCoZevkBQryDsas3p29SUv8lOXNUVotMsZc50CTOfP6C5Ue8fkIDMV7zd8Q==",
+      "version": "0.1.0-next.5",
+      "resolved": "https://registry.npmjs.org/@redocly/api-docs/-/api-docs-0.1.0-next.5.tgz",
+      "integrity": "sha512-mkLgab5b+AfySN5clnKyonCW+tjonR6QOo5rAXIVoB7/pxXFT8/EL9ZB/xa5H1AOK20zHAgdnf5S8d6eHZIkYw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@markdoc/markdoc": "0.5.2",
         "@redocly/allof-merge": "0.6.9",
         "@redocly/config": "0.53.1",
-        "@redocly/openapi-core": "2.44.2",
+        "@redocly/openapi-core": "2.45.0",
         "@redocly/redoc-opentelemetry": "0.2.2",
-        "@redocly/replay": "0.27.0-next.8",
-        "@redocly/theme": "^0.68.0-next.6",
+        "@redocly/replay": "0.27.0-next.10",
+        "@redocly/theme": "^0.68.0-next.8",
         "dompurify": "3.4.12",
         "fast-xml-parser": "5.7.3",
         "graphql": "16.12.0",
@@ -2168,28 +2168,28 @@
         "linkedom": "^0.18.12",
         "openapi-sampler": "^1.7.2",
         "prismjs": "1.30.0",
-        "react-router-dom": "^7.18.1",
+        "react-router": "^8.3.0",
         "slugify": "^1.4.7",
         "swagger2openapi": "^7.0.8",
         "url-template": "^2.0.8",
         "web-vitals": "3.3.1"
       },
       "peerDependencies": {
-        "react": "^19.2.4",
-        "react-dom": "^19.2.4",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
         "styled-components": "^6.4.2"
       }
     },
     "node_modules/@redocly/api-docs/node_modules/@redocly/replay": {
-      "version": "0.27.0-next.8",
-      "resolved": "https://registry.npmjs.org/@redocly/replay/-/replay-0.27.0-next.8.tgz",
-      "integrity": "sha512-Xf9k3P2vZRqgmJ+ru9NnbejuIrpfBHjLh8Ns1wkS6xzuD22ub1X5dSexWTcTCQuIXAF+2vaQVDgE3lwB5pXdUQ==",
+      "version": "0.27.0-next.10",
+      "resolved": "https://registry.npmjs.org/@redocly/replay/-/replay-0.27.0-next.10.tgz",
+      "integrity": "sha512-rJ1unvcJkjEIKYqYi4OdIUbSOUIQjndSftwegCUlqGcq4ZLsLsT9sE1/ZK3yh9AAAWuXAHcAr5JclAdX/5hvUQ==",
       "peerDependencies": {
-        "@redocly/theme": "0.68.0-next.6",
+        "@redocly/theme": "0.68.0-next.8",
         "@tanstack/react-query": "5.62.3",
-        "react": "^19.2.4",
-        "react-dom": "^19.2.4",
-        "react-router-dom": "^7.18.1",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
+        "react-router": "^8.3.0",
         "styled-components": "^6.4.2"
       }
     },
@@ -2203,24 +2203,24 @@
       }
     },
     "node_modules/@redocly/asyncapi-docs": {
-      "version": "1.13.0-next.9",
-      "resolved": "https://registry.npmjs.org/@redocly/asyncapi-docs/-/asyncapi-docs-1.13.0-next.9.tgz",
-      "integrity": "sha512-Xum+M+G8Z9pDaA3B7Q6mtyQC5uFRwvjqpWV+O6YuQbiL7CCnxL2wzcv+mTDIH2wYUNiZiJmKaxU9HqNP+pqbiw==",
+      "version": "1.13.0-next.11",
+      "resolved": "https://registry.npmjs.org/@redocly/asyncapi-docs/-/asyncapi-docs-1.13.0-next.11.tgz",
+      "integrity": "sha512-evjjerIrojLqnuj3DdMKKRJ90rKu7C9OpA6nTuwJCxQegTvYSoc+iOwomlCBDlH9HtSixJ79kvkvZyi9RbJYxA==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@markdoc/markdoc": "0.5.2",
         "@redocly/config": "0.53.1",
-        "@redocly/openapi-docs": "3.24.0-next.9",
+        "@redocly/openapi-docs": "3.24.0-next.11",
         "@redocly/redoc-opentelemetry": "0.2.2",
-        "@redocly/theme": "0.68.0-next.6",
+        "@redocly/theme": "0.68.0-next.8",
         "jotai": "^2.11.1",
         "openapi-sampler": "^1.7.2",
-        "react-router-dom": "^7.18.1",
+        "react-router": "^8.3.0",
         "styled-components": "^6.4.2",
         "web-vitals": "3.3.1"
       },
       "peerDependencies": {
-        "react": "^19.2.4"
+        "react": "^19.2.7"
       }
     },
     "node_modules/@redocly/config": {
@@ -2259,9 +2259,9 @@
       "license": "SEE LICENSE IN LICENSE"
     },
     "node_modules/@redocly/marketing-pages": {
-      "version": "0.2.22",
-      "resolved": "https://registry.npmjs.org/@redocly/marketing-pages/-/marketing-pages-0.2.22.tgz",
-      "integrity": "sha512-RWuJDR2C2e7KPdRuwd+YB78i/auyF9kCLR0rRGoZLhnBIQrDIhVuCxcTdVff76VHLqpxOcnBVV4zkEO1anb1Qg==",
+      "version": "0.2.23",
+      "resolved": "https://registry.npmjs.org/@redocly/marketing-pages/-/marketing-pages-0.2.23.tgz",
+      "integrity": "sha512-uK883XvBjeVEDnqMfQYrkHVn6X6hRdfPgJP1SV5GkyuVkRSuTkluhTRsiE7Ynx5gVqDvgWi6RcJkqsWuyOU4Ig==",
       "license": "UNLICENSED",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.1",
@@ -2273,7 +2273,7 @@
         "@react-spring/web": "^10.1.0",
         "@rebilly/lead-source-tracker": "^2.18.13",
         "@redocly/json-to-json-schema": "^0.0.1",
-        "@redocly/openapi-language-server": "0.10.6",
+        "@redocly/openapi-language-server": "0.10.7",
         "@uiw/react-codemirror": "^4.21.20",
         "csstype": "^3.1.2",
         "dayjs": "1.11.21",
@@ -2301,10 +2301,10 @@
         "ulid": "^2.3.0"
       },
       "peerDependencies": {
-        "@redocly/realm": "0.136.0-next.10",
-        "@redocly/theme": "0.68.0-next.6",
-        "react": "^19.2.4",
-        "react-dom": "^19.2.4",
+        "@redocly/realm": "0.136.0-next.13",
+        "@redocly/theme": "0.68.0-next.8",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
         "styled-components": "^6.4.2"
       }
     },
@@ -2325,13 +2325,13 @@
       }
     },
     "node_modules/@redocly/mock-server": {
-      "version": "0.10.0-next.3",
-      "resolved": "https://registry.npmjs.org/@redocly/mock-server/-/mock-server-0.10.0-next.3.tgz",
-      "integrity": "sha512-JGtDPIjOwBV5z3g5Mo4jABAXqegA9OqljMrctrbpYapchtnOVAnOBnhpgufqwUACgt23U/f+hoeTIVQRUVICjQ==",
+      "version": "0.10.0-next.4",
+      "resolved": "https://registry.npmjs.org/@redocly/mock-server/-/mock-server-0.10.0-next.4.tgz",
+      "integrity": "sha512-ZRpY/FkaxSVJfJbhhvAPuLOObGDf/vj9/yWhSwWltg8OH03PghCWcpnbD2acMIoIw7vNNi1QXzNMC/LqWvMHrg==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@redocly/ajv": "8.18.0",
-        "@redocly/openapi-core": "2.44.2",
+        "@redocly/openapi-core": "2.45.0",
         "ajv": "8.18.0",
         "ajv-formats": "^3.0.1",
         "fast-xml-parser": "5.7.3",
@@ -2376,9 +2376,9 @@
       }
     },
     "node_modules/@redocly/openapi-core": {
-      "version": "2.44.2",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.44.2.tgz",
-      "integrity": "sha512-dYG8ZNV6+8zCUY1Q/HNBUuY1EOAOimHaSr/X18NlSDZSy3x4Q0PGnXXxKDKA4T+k59+CKwZCl8vRyw1j09+agg==",
+      "version": "2.45.0",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.45.0.tgz",
+      "integrity": "sha512-a8NsUpiE4M3sfNEI+BuEHNqslcn19nE2AP1mw5hvDnEsnJRDCgPk+Sy1zyQCCnmiisk9vy+XlVzFXPraPrAW4g==",
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.18.1",
@@ -2421,17 +2421,17 @@
       }
     },
     "node_modules/@redocly/openapi-docs": {
-      "version": "3.24.0-next.9",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-docs/-/openapi-docs-3.24.0-next.9.tgz",
-      "integrity": "sha512-uh68CQZLDlp1rhTrrQXZ5rd39BMGA8Bq7hSqbT3pyK4CM82rq5k2qpNpA2kBvxAuDGwOZx8tPRFMKT85ojhR6w==",
+      "version": "3.24.0-next.11",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-docs/-/openapi-docs-3.24.0-next.11.tgz",
+      "integrity": "sha512-26KPq+0B2HTgQb729FAWSEHuaDZs7x/gcQA5BuINF/Ac8ni3kl7+9lCEmjW5dw2DFaK1J+QJpBNy8e/1Lgbv2A==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@babel/core": "7.29.7",
         "@markdoc/markdoc": "0.5.2",
         "@redocly/config": "0.53.1",
-        "@redocly/openapi-core": "2.44.2",
+        "@redocly/openapi-core": "2.45.0",
         "@redocly/redoc-opentelemetry": "0.2.2",
-        "@redocly/replay": "0.27.0-next.8",
+        "@redocly/replay": "0.27.0-next.10",
         "deepmerge": "^4.2.2",
         "dompurify": "3.4.12",
         "fast-deep-equal": "^3.1.3",
@@ -2440,7 +2440,7 @@
         "jotai-family": "1.0.1",
         "json-pointer": "^0.6.2",
         "openapi-sampler": "^1.7.2",
-        "react-router-dom": "^7.18.1",
+        "react-router": "^8.3.0",
         "slugify": "^1.4.7",
         "stringify-object": "^3.3.0",
         "styled-components": "^6.4.2",
@@ -2455,28 +2455,28 @@
       },
       "peerDependencies": {
         "@redocly/theme": ">=0.68.0-next.0",
-        "react": "^19.2.4",
-        "react-dom": "^19.2.4",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
         "styled-components": "^4.1.1 || ^5.3.11 || ^6.0.0"
       }
     },
     "node_modules/@redocly/openapi-docs/node_modules/@redocly/replay": {
-      "version": "0.27.0-next.8",
-      "resolved": "https://registry.npmjs.org/@redocly/replay/-/replay-0.27.0-next.8.tgz",
-      "integrity": "sha512-Xf9k3P2vZRqgmJ+ru9NnbejuIrpfBHjLh8Ns1wkS6xzuD22ub1X5dSexWTcTCQuIXAF+2vaQVDgE3lwB5pXdUQ==",
+      "version": "0.27.0-next.10",
+      "resolved": "https://registry.npmjs.org/@redocly/replay/-/replay-0.27.0-next.10.tgz",
+      "integrity": "sha512-rJ1unvcJkjEIKYqYi4OdIUbSOUIQjndSftwegCUlqGcq4ZLsLsT9sE1/ZK3yh9AAAWuXAHcAr5JclAdX/5hvUQ==",
       "peerDependencies": {
-        "@redocly/theme": "0.68.0-next.6",
+        "@redocly/theme": "0.68.0-next.8",
         "@tanstack/react-query": "5.62.3",
-        "react": "^19.2.4",
-        "react-dom": "^19.2.4",
-        "react-router-dom": "^7.18.1",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
+        "react-router": "^8.3.0",
         "styled-components": "^6.4.2"
       }
     },
     "node_modules/@redocly/openapi-language-server": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-language-server/-/openapi-language-server-0.10.6.tgz",
-      "integrity": "sha512-AHNPgyvEUkvcVK05OqbIM6rTCf99Z8xdaJ/S6vHKmKb93d4PnuTtTjxxJtT0T80YdLAVvpwRYt64H2HsY8j5Zg==",
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-language-server/-/openapi-language-server-0.10.7.tgz",
+      "integrity": "sha512-4oOtGjaOrvODKOukA/YGQSZVDCCsB1aJydLOHbWyxHALTk/7c6O4HsAx5XiUD2u5Hi9JTZc3zJk7SzyhZCCkUg==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@redocly/config": "0.53.1",
@@ -2486,37 +2486,24 @@
         "vscode-uri": "^3.1.0"
       },
       "peerDependencies": {
-        "@redocly/openapi-core": "2.44.2"
-      }
-    },
-    "node_modules/@redocly/portal-legacy-ui": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@redocly/portal-legacy-ui/-/portal-legacy-ui-0.18.0.tgz",
-      "integrity": "sha512-PGENlGtg/7Z1n1P7iBge4cnQLNmVWOOt8PwoypRv0ylNV8WYhCIKm+TW3sLaSSdYvwKDV5HFAMXRT9RfQ5IBlA==",
-      "license": "SEE LICENSE IN LICENSE",
-      "peerDependencies": {
-        "highlight-words-core": "^1.2.2",
-        "react": "^19.2.4",
-        "react-router-dom": "^6.30.3",
-        "styled-components": "^4.1.1 || ^5.3.11 || ^6.0.0",
-        "styled-system": "^5.1.5"
+        "@redocly/openapi-core": "2.45.0"
       }
     },
     "node_modules/@redocly/portal-plugin-mock-server": {
-      "version": "0.21.0-next.9",
-      "resolved": "https://registry.npmjs.org/@redocly/portal-plugin-mock-server/-/portal-plugin-mock-server-0.21.0-next.9.tgz",
-      "integrity": "sha512-mh5DqQqGPQA5a+qipKtIiOvTHKwiNmfuKvCioLeMcGf3+QpwN8Tk4rXzH8C9RGRmlXBjEXRdOr35eeaC7tOQAw==",
+      "version": "0.21.0-next.11",
+      "resolved": "https://registry.npmjs.org/@redocly/portal-plugin-mock-server/-/portal-plugin-mock-server-0.21.0-next.11.tgz",
+      "integrity": "sha512-bd5qOAyw+mVVr3ET8TK4PY45U2lf+PFY8wxhTs2n/K5qwB75Y4WwyYuTr+TJbJT6PojKPY/KH38J4gmdHPXw0Q==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@redocly/config": "0.53.1",
-        "@redocly/mock-server": "0.10.0-next.3",
-        "@redocly/openapi-docs": "3.24.0-next.9"
+        "@redocly/mock-server": "0.10.0-next.4",
+        "@redocly/openapi-docs": "3.24.0-next.11"
       }
     },
     "node_modules/@redocly/realm": {
-      "version": "0.136.0-next.10",
-      "resolved": "https://registry.npmjs.org/@redocly/realm/-/realm-0.136.0-next.10.tgz",
-      "integrity": "sha512-tX/OIlItu4WLKtDmUqYNsJ+57N1kktLPCKfQ7aYOeZlX5LcFYb++8zVtrNCNyri5kglYcM0XyjYPxQxJZ4j8xw==",
+      "version": "0.136.0-next.13",
+      "resolved": "https://registry.npmjs.org/@redocly/realm/-/realm-0.136.0-next.13.tgz",
+      "integrity": "sha512-JLNrbkl4c70Ss9FYqDxtWSYC1rdzqzTlBKSwUoHs5g/HJnQcsT44z0Jim9toRaDOnFWz97BNEpyr8+N0yOHp2w==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@babel/core": "7.29.7",
@@ -2538,16 +2525,16 @@
         "@opentelemetry/sdk-trace-web": "2.8.0",
         "@opentelemetry/semantic-conventions": "1.40.0",
         "@redocly/ajv": "8.18.0",
-        "@redocly/api-docs": "0.1.0-next.2",
-        "@redocly/asyncapi-docs": "1.13.0-next.9",
+        "@redocly/api-docs": "0.1.0-next.5",
+        "@redocly/asyncapi-docs": "1.13.0-next.11",
         "@redocly/config": "0.53.1",
-        "@redocly/graphql-docs": "1.13.0-next.9",
-        "@redocly/openapi-core": "2.44.2",
-        "@redocly/openapi-docs": "3.24.0-next.9",
-        "@redocly/portal-legacy-ui": "0.18.0",
-        "@redocly/portal-plugin-mock-server": "0.21.0-next.9",
+        "@redocly/graphql-docs": "1.13.0-next.11",
+        "@redocly/openapi-core": "2.45.0",
+        "@redocly/openapi-docs": "3.24.0-next.11",
+        "@redocly/portal-legacy-ui": "0.19.0-next.0",
+        "@redocly/portal-plugin-mock-server": "0.21.0-next.11",
         "@redocly/realm-asyncapi-sdk": "0.14.0-next.3",
-        "@redocly/theme": "0.68.0-next.6",
+        "@redocly/theme": "0.68.0-next.8",
         "@shikijs/transformers": "3.21.0",
         "@tanstack/react-query": "5.62.3",
         "@tanstack/react-table": "8.21.3",
@@ -2583,11 +2570,11 @@
         "path-browserify": "1.0.1",
         "picomatch": "2.3.2",
         "quickjs-emscripten-core": "0.32.0",
-        "react": "^19.2.4",
+        "react": "^19.2.7",
         "react-calendar": "5.1.0",
         "react-date-picker": "11.0.0",
-        "react-dom": "^19.2.4",
-        "react-router-dom": "^7.18.1",
+        "react-dom": "^19.2.7",
+        "react-router": "^8.3.0",
         "react-select": "5.10.1",
         "reactjs-popup": "2.0.6",
         "semver": "7.7.3",
@@ -2612,12 +2599,12 @@
         "realm": "bin.js"
       },
       "engines": {
-        "node": ">=22.12.0 || >=20.19.0 <21.0.0",
+        "node": ">=22.22.0",
         "npm": ">=10"
       },
       "peerDependencies": {
-        "react": "^19.2.4",
-        "react-dom": "^19.2.4"
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7"
       }
     },
     "node_modules/@redocly/realm-asyncapi-sdk": {
@@ -2646,25 +2633,38 @@
       }
     },
     "node_modules/@redocly/realm/node_modules/@redocly/graphql-docs": {
-      "version": "1.13.0-next.9",
-      "resolved": "https://registry.npmjs.org/@redocly/graphql-docs/-/graphql-docs-1.13.0-next.9.tgz",
-      "integrity": "sha512-ebSvqxA5J8goCsjw3Kb6WzRyhy+ysrXoSafS6RoeI82QjLC1ScIJXcoLiAorbkz7W0NCOmHDaWjwkM1Q3iwvng==",
+      "version": "1.13.0-next.11",
+      "resolved": "https://registry.npmjs.org/@redocly/graphql-docs/-/graphql-docs-1.13.0-next.11.tgz",
+      "integrity": "sha512-V2tEaoEd9Hs90su61wx0ZBRc2O8KSoLo4IoD0dMM4Jhvy8467GvDZtBfp70aZKHI+QNXRorL4e9uRBh5droaoA==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@redocly/config": "0.53.1",
-        "@redocly/openapi-docs": "3.24.0-next.9",
+        "@redocly/openapi-docs": "3.24.0-next.11",
         "@redocly/redoc-opentelemetry": "0.2.2",
         "deepmerge": "^4.2.2",
         "marked": "^4.0.15",
         "web-vitals": "3.3.1"
       },
       "peerDependencies": {
-        "@redocly/theme": "0.68.0-next.6",
+        "@redocly/theme": "0.68.0-next.8",
         "graphql": "16.12.0",
-        "react": "^19.2.4",
-        "react-dom": "^19.2.4",
-        "react-router-dom": "^7.18.1",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
+        "react-router": "^8.3.0",
         "styled-components": "^5.3.11 || ^6.0.0"
+      }
+    },
+    "node_modules/@redocly/realm/node_modules/@redocly/portal-legacy-ui": {
+      "version": "0.19.0-next.0",
+      "resolved": "https://registry.npmjs.org/@redocly/portal-legacy-ui/-/portal-legacy-ui-0.19.0-next.0.tgz",
+      "integrity": "sha512-BQBr0JlDKJmtMmNEXusz4c6BDQVJTygQjFCdP2xpj9qFj5f94MAQEEvvwaZ95ig9wI3MGCyhPbjO4ZnjDpP4+Q==",
+      "license": "SEE LICENSE IN LICENSE",
+      "peerDependencies": {
+        "highlight-words-core": "^1.2.2",
+        "react": "^19.2.7",
+        "react-router": "^8.3.0",
+        "styled-components": "^4.1.1 || ^5.3.11 || ^6.0.0",
+        "styled-system": "^5.1.5"
       }
     },
     "node_modules/@redocly/realm/node_modules/colorette": {
@@ -2681,6 +2681,13 @@
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
+    },
+    "node_modules/@redocly/realm/node_modules/highlight-words-core": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/highlight-words-core/-/highlight-words-core-1.2.2.tgz",
+      "integrity": "sha512-BXUKIkUuh6cmmxzi5OIbUJxrG8OAk2MqoL1DtO3Wo9D2faJg2ph5ntyuQeLqaHJmzER6H5tllCDA9ZnNe9BVGg==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@redocly/realm/node_modules/marked": {
       "version": "4.3.0",
@@ -2713,9 +2720,9 @@
       "license": "MIT"
     },
     "node_modules/@redocly/theme": {
-      "version": "0.68.0-next.6",
-      "resolved": "https://registry.npmjs.org/@redocly/theme/-/theme-0.68.0-next.6.tgz",
-      "integrity": "sha512-iu+OPlPxuyP+iksUdY6MA6AS1ISpXN/kk3Tr8uIuqjnN+Fm4dUXjz0S6F8ID4IFoUZJQD4djJ+X+f3hJV5i9lg==",
+      "version": "0.68.0-next.8",
+      "resolved": "https://registry.npmjs.org/@redocly/theme/-/theme-0.68.0-next.8.tgz",
+      "integrity": "sha512-zsOhh+qk2glY9D+bUMzFmuPAXkLTIUVhDOH8MKJaEvIczeh/CHLK6QoahEXRvvt7aI3Gv/a7PCebyQxTTu9n2Q==",
       "license": "MIT",
       "dependencies": {
         "@redocly/config": "0.53.1",
@@ -2739,9 +2746,9 @@
         "@markdoc/markdoc": "0.5.2",
         "lodash.debounce": "^4.0.8",
         "lodash.throttle": "^4.1.1",
-        "react": "^19.2.4",
-        "react-dom": "^19.2.4",
-        "react-router-dom": "^7.18.1",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
+        "react-router": "^8.3.0",
         "styled-components": "^4.1.1 || ^5.3.11 || ^6.0.0"
       }
     },
@@ -4603,18 +4610,11 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/copy-to-clipboard": {
       "version": "3.3.3",
@@ -9113,41 +9113,24 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
-      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
-      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.18.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/react-select": {
@@ -9533,12 +9516,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "UNLICENSED",
       "dependencies": {
-        "@redocly/marketing-pages": "^0.2.23",
+        "@redocly/marketing-pages": "0.2.23",
         "@redocly/realm": "0.136.0-next.13",
         "buffer": "^6.0.3",
         "highlight-words-core": "^1.2.3",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   "author": "team@redocly.com",
   "license": "UNLICENSED",
   "dependencies": {
-    "@redocly/marketing-pages": "0.2.22",
-    "@redocly/realm": "0.136.0-next.10",
+    "@redocly/marketing-pages": "^0.2.23",
+    "@redocly/realm": "0.136.0-next.13",
     "buffer": "^6.0.3",
     "highlight-words-core": "^1.2.3",
     "path": "^0.12.7",
@@ -40,6 +40,6 @@
     "js-cookie@<3.0.7": "3.0.7",
     "markdown-it@<14.2.0": "14.3.0",
     "dompurify@<3.4.13": "3.4.13",
-    "@redocly/realm": "0.136.0-next.10"
+    "@redocly/realm": "0.136.0-next.13"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "team@redocly.com",
   "license": "UNLICENSED",
   "dependencies": {
-    "@redocly/marketing-pages": "^0.2.23",
+    "@redocly/marketing-pages": "0.2.23",
     "@redocly/realm": "0.136.0-next.13",
     "buffer": "^6.0.3",
     "highlight-words-core": "^1.2.3",


### PR DESCRIPTION
## What/Why/How?
Bump `realm` to latest version - `v0.136.0-next.13`
Bump `marketing-pages` to latest version - `v0.2.23`

`@redocly/realm@0.136.0-next.13` upgraded the router dependency to `react-router@8.3.0`. As of react-router v7+, the `react-router-dom` package was merged into `react-router`, so the import source from `react-router-dom` to `react-router` were updated.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
