### PR TITLE
chore: bump realm and marketing-pages versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "license": "UNLICENSED",
       "dependencies": {
-        "@redocly/marketing-pages": "0.2.24",
-        "@redocly/realm": "0.136.0-next.13",
+        "@redocly/marketing-pages": "0.2.25",
+        "@redocly/realm": "0.136.0-next.15",
         "buffer": "^6.0.3",
         "highlight-words-core": "^1.2.3",
         "path": "^0.12.7",
@@ -449,6 +449,18 @@
         "dompurify": "3.3.1",
         "jschardet": "3.1.4",
         "marked": "14.0.0"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-api/node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/@codingame/monaco-vscode-base-service-override": {
@@ -2146,9 +2158,9 @@
       }
     },
     "node_modules/@redocly/api-docs": {
-      "version": "0.1.0-next.5",
-      "resolved": "https://registry.npmjs.org/@redocly/api-docs/-/api-docs-0.1.0-next.5.tgz",
-      "integrity": "sha512-mkLgab5b+AfySN5clnKyonCW+tjonR6QOo5rAXIVoB7/pxXFT8/EL9ZB/xa5H1AOK20zHAgdnf5S8d6eHZIkYw==",
+      "version": "0.1.0-next.7",
+      "resolved": "https://registry.npmjs.org/@redocly/api-docs/-/api-docs-0.1.0-next.7.tgz",
+      "integrity": "sha512-hkxpKTYfHRyG0kFo7Wf7nKTBHTJwYkQ5UefWX1tSsePkjT+QD1/D7VKDjLzZSmlmgY9UXaHRDxz1+oKv/kAZDQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@markdoc/markdoc": "0.5.2",
@@ -2156,14 +2168,14 @@
         "@redocly/config": "0.53.1",
         "@redocly/openapi-core": "2.45.0",
         "@redocly/redoc-opentelemetry": "0.2.2",
-        "@redocly/replay": "0.27.0-next.10",
-        "@redocly/theme": "^0.68.0-next.8",
-        "dompurify": "3.4.12",
+        "@redocly/replay": "0.27.0-next.12",
+        "@redocly/theme": "^0.68.0-next.9",
+        "dompurify": "3.4.13",
         "fast-xml-parser": "5.7.3",
-        "graphql": "16.12.0",
+        "graphql": "16.14.2",
         "jotai": "^2.16.2",
         "jotai-family": "1.0.1",
-        "js-yaml": "4.3.0",
+        "js-yaml": "4.3.1",
         "json-pointer": "^0.6.2",
         "linkedom": "^0.18.12",
         "openapi-sampler": "^1.7.2",
@@ -2180,39 +2192,17 @@
         "styled-components": "^6.4.2"
       }
     },
-    "node_modules/@redocly/api-docs/node_modules/@redocly/replay": {
-      "version": "0.27.0-next.10",
-      "resolved": "https://registry.npmjs.org/@redocly/replay/-/replay-0.27.0-next.10.tgz",
-      "integrity": "sha512-rJ1unvcJkjEIKYqYi4OdIUbSOUIQjndSftwegCUlqGcq4ZLsLsT9sE1/ZK3yh9AAAWuXAHcAr5JclAdX/5hvUQ==",
-      "peerDependencies": {
-        "@redocly/theme": "0.68.0-next.8",
-        "@tanstack/react-query": "5.62.3",
-        "react": "^19.2.7",
-        "react-dom": "^19.2.7",
-        "react-router": "^8.3.0",
-        "styled-components": "^6.4.2"
-      }
-    },
-    "node_modules/@redocly/api-docs/node_modules/graphql": {
-      "version": "16.12.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
-      "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
-      }
-    },
     "node_modules/@redocly/asyncapi-docs": {
-      "version": "1.13.0-next.11",
-      "resolved": "https://registry.npmjs.org/@redocly/asyncapi-docs/-/asyncapi-docs-1.13.0-next.11.tgz",
-      "integrity": "sha512-evjjerIrojLqnuj3DdMKKRJ90rKu7C9OpA6nTuwJCxQegTvYSoc+iOwomlCBDlH9HtSixJ79kvkvZyi9RbJYxA==",
+      "version": "1.13.0-next.13",
+      "resolved": "https://registry.npmjs.org/@redocly/asyncapi-docs/-/asyncapi-docs-1.13.0-next.13.tgz",
+      "integrity": "sha512-AGV0EC7TGfn7aT+3FU966zzNmfcp+RT7LTWbCNjO7vQEMiisFsynpa3NmNZU32IKoLuhiYcCeNsr4QKKElo+0g==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@markdoc/markdoc": "0.5.2",
         "@redocly/config": "0.53.1",
-        "@redocly/openapi-docs": "3.24.0-next.11",
+        "@redocly/openapi-docs": "3.24.0-next.13",
         "@redocly/redoc-opentelemetry": "0.2.2",
-        "@redocly/theme": "0.68.0-next.8",
+        "@redocly/theme": "0.68.0-next.9",
         "jotai": "^2.11.1",
         "openapi-sampler": "^1.7.2",
         "react-router": "^8.3.0",
@@ -2232,25 +2222,27 @@
         "json-schema-to-ts": "2.7.2"
       }
     },
-    "node_modules/@redocly/config/node_modules/json-schema-to-ts": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-2.7.2.tgz",
-      "integrity": "sha512-R1JfqKqbBR4qE8UyBR56Ms30LL62/nlhoz+1UkfI/VE7p54Awu919FZ6ZUPG8zIa3XB65usPJgr1ONVncUGSaQ==",
-      "license": "MIT",
+    "node_modules/@redocly/graphql-docs": {
+      "version": "1.13.0-next.13",
+      "resolved": "https://registry.npmjs.org/@redocly/graphql-docs/-/graphql-docs-1.13.0-next.13.tgz",
+      "integrity": "sha512-WwEPpk+FMFdbDD0ONcxssT/u3fcg2U4rN4f8B907zS/qhHs9yEKFuUp53vUqjxISXxFTyJA/0KcY0OqWQZzByA==",
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "@types/json-schema": "^7.0.9",
-        "ts-algebra": "^1.2.0"
+        "@redocly/config": "0.53.1",
+        "@redocly/openapi-docs": "3.24.0-next.13",
+        "@redocly/redoc-opentelemetry": "0.2.2",
+        "deepmerge": "^4.2.2",
+        "marked": "^4.0.15",
+        "web-vitals": "3.3.1"
       },
-      "engines": {
-        "node": ">=16"
+      "peerDependencies": {
+        "@redocly/theme": "0.68.0-next.9",
+        "graphql": "16.14.2",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
+        "react-router": "^8.3.0",
+        "styled-components": "^5.3.11 || ^6.0.0"
       }
-    },
-    "node_modules/@redocly/config/node_modules/ts-algebra": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-1.2.2.tgz",
-      "integrity": "sha512-kloPhf1hq3JbCPOTYoOWDKxebWjNb2o/LKnNfkWhxVVisFFmMJPPdJeGoGmM+iRLyoXAR61e08Pb+vUXINg8aA==",
-      "license": "MIT"
     },
     "node_modules/@redocly/json-to-json-schema": {
       "version": "0.0.1",
@@ -2259,9 +2251,9 @@
       "license": "SEE LICENSE IN LICENSE"
     },
     "node_modules/@redocly/marketing-pages": {
-      "version": "0.2.24",
-      "resolved": "https://registry.npmjs.org/@redocly/marketing-pages/-/marketing-pages-0.2.24.tgz",
-      "integrity": "sha512-Mxc/BBqWyKairMgPj4cOIHg16oQEELNIiXmtxybBM6lZWkeKSpNQpYjPHCxPmfVsPZjhH2xjq3WzOFtGheZfkw==",
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/@redocly/marketing-pages/-/marketing-pages-0.2.25.tgz",
+      "integrity": "sha512-xkRa/tuE2BYgJmq9Y7+xT50vugW6OUOhRY9ezvoop6nog55uJgoTWAzzAaGvzVsYAyJrGPBit6/KElTRTZY9+g==",
       "license": "UNLICENSED",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.1",
@@ -2281,7 +2273,7 @@
         "highlight-words-core": "1.2.2",
         "html2canvas": "^1.4.1",
         "js-cookie": "^3.0.6",
-        "js-yaml": "4.3.0",
+        "js-yaml": "4.3.1",
         "json-schema-to-ts": "^3.1.0",
         "jspdf": "^4.2.1",
         "lottie-react": "^2.4.0",
@@ -2301,8 +2293,8 @@
         "ulid": "^2.3.0"
       },
       "peerDependencies": {
-        "@redocly/realm": "0.136.0-next.13",
-        "@redocly/theme": "0.68.0-next.8",
+        "@redocly/realm": "0.136.0-next.15",
+        "@redocly/theme": "0.68.0-next.9",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "styled-components": "^6.4.2"
@@ -2314,6 +2306,19 @@
       "integrity": "sha512-BXUKIkUuh6cmmxzi5OIbUJxrG8OAk2MqoL1DtO3Wo9D2faJg2ph5ntyuQeLqaHJmzER6H5tllCDA9ZnNe9BVGg==",
       "license": "MIT"
     },
+    "node_modules/@redocly/marketing-pages/node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/@redocly/marketing-pages/node_modules/monaco-editor": {
       "name": "@codingame/monaco-vscode-editor-api",
       "version": "25.1.2",
@@ -2324,10 +2329,16 @@
         "@codingame/monaco-vscode-api": "25.1.2"
       }
     },
+    "node_modules/@redocly/marketing-pages/node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
     "node_modules/@redocly/mock-server": {
-      "version": "0.10.0-next.4",
-      "resolved": "https://registry.npmjs.org/@redocly/mock-server/-/mock-server-0.10.0-next.4.tgz",
-      "integrity": "sha512-ZRpY/FkaxSVJfJbhhvAPuLOObGDf/vj9/yWhSwWltg8OH03PghCWcpnbD2acMIoIw7vNNi1QXzNMC/LqWvMHrg==",
+      "version": "0.10.0-next.5",
+      "resolved": "https://registry.npmjs.org/@redocly/mock-server/-/mock-server-0.10.0-next.5.tgz",
+      "integrity": "sha512-WWfy9WSWxANOPhb1K7vO2Bsr57c6ir/uJl0HYonLXCN9vDzbLwEmoc1Ji2DC881UoocTIWfM2CMR0mkqIUAfXg==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@redocly/ajv": "8.18.0",
@@ -2335,7 +2346,7 @@
         "ajv": "8.18.0",
         "ajv-formats": "^3.0.1",
         "fast-xml-parser": "5.7.3",
-        "js-yaml": "4.3.0",
+        "js-yaml": "4.3.1",
         "openapi-sampler": "^1.7.2",
         "punycode": "2.3.0",
         "swagger2openapi": "^7.0.8",
@@ -2421,9 +2432,9 @@
       }
     },
     "node_modules/@redocly/openapi-docs": {
-      "version": "3.24.0-next.11",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-docs/-/openapi-docs-3.24.0-next.11.tgz",
-      "integrity": "sha512-26KPq+0B2HTgQb729FAWSEHuaDZs7x/gcQA5BuINF/Ac8ni3kl7+9lCEmjW5dw2DFaK1J+QJpBNy8e/1Lgbv2A==",
+      "version": "3.24.0-next.13",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-docs/-/openapi-docs-3.24.0-next.13.tgz",
+      "integrity": "sha512-ZJFmSTOc1Rst1BJIQAz+BwyKDu9Y5iYEbTJYKIiTW1wz2Wu0E/SKZ4p9ze9eoD8xZdHjUTQ8T/upWe8SM5wPXw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@babel/core": "7.29.7",
@@ -2431,9 +2442,9 @@
         "@redocly/config": "0.53.1",
         "@redocly/openapi-core": "2.45.0",
         "@redocly/redoc-opentelemetry": "0.2.2",
-        "@redocly/replay": "0.27.0-next.10",
+        "@redocly/replay": "0.27.0-next.12",
         "deepmerge": "^4.2.2",
-        "dompurify": "3.4.12",
+        "dompurify": "3.4.13",
         "fast-deep-equal": "^3.1.3",
         "fast-xml-parser": "5.7.3",
         "jotai": "^2.12.5",
@@ -2460,19 +2471,6 @@
         "styled-components": "^4.1.1 || ^5.3.11 || ^6.0.0"
       }
     },
-    "node_modules/@redocly/openapi-docs/node_modules/@redocly/replay": {
-      "version": "0.27.0-next.10",
-      "resolved": "https://registry.npmjs.org/@redocly/replay/-/replay-0.27.0-next.10.tgz",
-      "integrity": "sha512-rJ1unvcJkjEIKYqYi4OdIUbSOUIQjndSftwegCUlqGcq4ZLsLsT9sE1/ZK3yh9AAAWuXAHcAr5JclAdX/5hvUQ==",
-      "peerDependencies": {
-        "@redocly/theme": "0.68.0-next.8",
-        "@tanstack/react-query": "5.62.3",
-        "react": "^19.2.7",
-        "react-dom": "^19.2.7",
-        "react-router": "^8.3.0",
-        "styled-components": "^6.4.2"
-      }
-    },
     "node_modules/@redocly/openapi-language-server": {
       "version": "0.10.7",
       "resolved": "https://registry.npmjs.org/@redocly/openapi-language-server/-/openapi-language-server-0.10.7.tgz",
@@ -2490,20 +2488,20 @@
       }
     },
     "node_modules/@redocly/portal-plugin-mock-server": {
-      "version": "0.21.0-next.11",
-      "resolved": "https://registry.npmjs.org/@redocly/portal-plugin-mock-server/-/portal-plugin-mock-server-0.21.0-next.11.tgz",
-      "integrity": "sha512-bd5qOAyw+mVVr3ET8TK4PY45U2lf+PFY8wxhTs2n/K5qwB75Y4WwyYuTr+TJbJT6PojKPY/KH38J4gmdHPXw0Q==",
+      "version": "0.21.0-next.13",
+      "resolved": "https://registry.npmjs.org/@redocly/portal-plugin-mock-server/-/portal-plugin-mock-server-0.21.0-next.13.tgz",
+      "integrity": "sha512-CgxS5LxWau8d5+zpOwOoij7w/nV/tBBlVpVCT7P3AYGrviBQXl12YTGYBMrxoL71zIx0Jvs+01La4aPBUGVnBg==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@redocly/config": "0.53.1",
-        "@redocly/mock-server": "0.10.0-next.4",
-        "@redocly/openapi-docs": "3.24.0-next.11"
+        "@redocly/mock-server": "0.10.0-next.5",
+        "@redocly/openapi-docs": "3.24.0-next.13"
       }
     },
     "node_modules/@redocly/realm": {
-      "version": "0.136.0-next.13",
-      "resolved": "https://registry.npmjs.org/@redocly/realm/-/realm-0.136.0-next.13.tgz",
-      "integrity": "sha512-JLNrbkl4c70Ss9FYqDxtWSYC1rdzqzTlBKSwUoHs5g/HJnQcsT44z0Jim9toRaDOnFWz97BNEpyr8+N0yOHp2w==",
+      "version": "0.136.0-next.15",
+      "resolved": "https://registry.npmjs.org/@redocly/realm/-/realm-0.136.0-next.15.tgz",
+      "integrity": "sha512-egvy4EOFtP6y1mtR0apuz7Zj1UhupIzWOcczP5jJGOs58cZqymPdsomToeeeyfECrhB3efbaa+CQXE4Ej3SR1g==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@babel/core": "7.29.7",
@@ -2525,16 +2523,16 @@
         "@opentelemetry/sdk-trace-web": "2.8.0",
         "@opentelemetry/semantic-conventions": "1.40.0",
         "@redocly/ajv": "8.18.0",
-        "@redocly/api-docs": "0.1.0-next.5",
-        "@redocly/asyncapi-docs": "1.13.0-next.11",
+        "@redocly/api-docs": "0.1.0-next.7",
+        "@redocly/asyncapi-docs": "1.13.0-next.13",
         "@redocly/config": "0.53.1",
-        "@redocly/graphql-docs": "1.13.0-next.11",
+        "@redocly/graphql-docs": "1.13.0-next.13",
         "@redocly/openapi-core": "2.45.0",
-        "@redocly/openapi-docs": "3.24.0-next.11",
+        "@redocly/openapi-docs": "3.24.0-next.13",
         "@redocly/portal-legacy-ui": "0.19.0-next.0",
-        "@redocly/portal-plugin-mock-server": "0.21.0-next.11",
-        "@redocly/realm-asyncapi-sdk": "0.14.0-next.3",
-        "@redocly/theme": "0.68.0-next.8",
+        "@redocly/portal-plugin-mock-server": "0.21.0-next.13",
+        "@redocly/realm-asyncapi-sdk": "0.14.0-next.4",
+        "@redocly/theme": "0.68.0-next.9",
         "@shikijs/transformers": "3.21.0",
         "@tanstack/react-query": "5.62.3",
         "@tanstack/react-table": "8.21.3",
@@ -2554,16 +2552,16 @@
         "escape-carriage": "^1.3.1",
         "fflate": "0.7.4",
         "flexsearch": "0.7.43",
-        "graphql": "16.12.0",
-        "hono": "4.12.34",
+        "graphql": "16.14.2",
+        "hono": "4.13.1",
         "htmlparser2": "8.0.2",
         "i18next": "22.4.15",
         "is-glob": "4.0.3",
-        "js-yaml": "4.3.0",
+        "js-yaml": "4.3.1",
         "lru-cache": "11.1.0",
         "minimatch": "10.2.4",
         "mri": "1.2.0",
-        "nanoid": "5.0.9",
+        "nanoid": "5.1.16",
         "nprogress": "0.2.0",
         "openapi-sampler": "^1.7.2",
         "os-browserify": "0.3.0",
@@ -2608,9 +2606,9 @@
       }
     },
     "node_modules/@redocly/realm-asyncapi-sdk": {
-      "version": "0.14.0-next.3",
-      "resolved": "https://registry.npmjs.org/@redocly/realm-asyncapi-sdk/-/realm-asyncapi-sdk-0.14.0-next.3.tgz",
-      "integrity": "sha512-ilMgcPS+RNbMW+y4xoZsZmchct8SZywE5pUMSGapdKvNtqaWbKFwgji62U7MGDr9or4T/bBdHWoFkKsC7gExxQ==",
+      "version": "0.14.0-next.4",
+      "resolved": "https://registry.npmjs.org/@redocly/realm-asyncapi-sdk/-/realm-asyncapi-sdk-0.14.0-next.4.tgz",
+      "integrity": "sha512-XnRys0ht/axkQhcuWZAPVc2yiVh65zN9w5QTXVkmoLwBXfd20cjklHBexDXZi+a6JEmiw94he0Fv5Se+GqU2jw==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "safe-stable-stringify": "2.5.0"
@@ -2632,28 +2630,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/@redocly/realm/node_modules/@redocly/graphql-docs": {
-      "version": "1.13.0-next.11",
-      "resolved": "https://registry.npmjs.org/@redocly/graphql-docs/-/graphql-docs-1.13.0-next.11.tgz",
-      "integrity": "sha512-V2tEaoEd9Hs90su61wx0ZBRc2O8KSoLo4IoD0dMM4Jhvy8467GvDZtBfp70aZKHI+QNXRorL4e9uRBh5droaoA==",
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@redocly/config": "0.53.1",
-        "@redocly/openapi-docs": "3.24.0-next.11",
-        "@redocly/redoc-opentelemetry": "0.2.2",
-        "deepmerge": "^4.2.2",
-        "marked": "^4.0.15",
-        "web-vitals": "3.3.1"
-      },
-      "peerDependencies": {
-        "@redocly/theme": "0.68.0-next.8",
-        "graphql": "16.12.0",
-        "react": "^19.2.7",
-        "react-dom": "^19.2.7",
-        "react-router": "^8.3.0",
-        "styled-components": "^5.3.11 || ^6.0.0"
-      }
-    },
     "node_modules/@redocly/realm/node_modules/@redocly/portal-legacy-ui": {
       "version": "0.19.0-next.0",
       "resolved": "https://registry.npmjs.org/@redocly/portal-legacy-ui/-/portal-legacy-ui-0.19.0-next.0.tgz",
@@ -2673,34 +2649,6 @@
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "license": "MIT"
     },
-    "node_modules/@redocly/realm/node_modules/graphql": {
-      "version": "16.12.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
-      "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@redocly/realm/node_modules/highlight-words-core": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/highlight-words-core/-/highlight-words-core-1.2.2.tgz",
-      "integrity": "sha512-BXUKIkUuh6cmmxzi5OIbUJxrG8OAk2MqoL1DtO3Wo9D2faJg2ph5ntyuQeLqaHJmzER6H5tllCDA9ZnNe9BVGg==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@redocly/realm/node_modules/marked": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/@redocly/realm/node_modules/picomatch": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
@@ -2719,10 +2667,23 @@
       "integrity": "sha512-gp9rkjtTfEMLNzph+7/7pnOtEjkjvz7dC5A10XQjzKDjqEJ9E55p14kvk1iFgpsztQFVQsYXMMdB1vGmU4/hBg==",
       "license": "MIT"
     },
+    "node_modules/@redocly/replay": {
+      "version": "0.27.0-next.12",
+      "resolved": "https://registry.npmjs.org/@redocly/replay/-/replay-0.27.0-next.12.tgz",
+      "integrity": "sha512-A1MNqT+qWN9IM2uAhvNqvUTBTU2ryenudgMv4TDMV9mUxa+jNqa3tHsYB5lSsjvMeY/Lr4A9YLJLXAf+yR/dyg==",
+      "peerDependencies": {
+        "@redocly/theme": "0.68.0-next.9",
+        "@tanstack/react-query": "5.62.3",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
+        "react-router": "^8.3.0",
+        "styled-components": "^6.4.2"
+      }
+    },
     "node_modules/@redocly/theme": {
-      "version": "0.68.0-next.8",
-      "resolved": "https://registry.npmjs.org/@redocly/theme/-/theme-0.68.0-next.8.tgz",
-      "integrity": "sha512-zsOhh+qk2glY9D+bUMzFmuPAXkLTIUVhDOH8MKJaEvIczeh/CHLK6QoahEXRvvt7aI3Gv/a7PCebyQxTTu9n2Q==",
+      "version": "0.68.0-next.9",
+      "resolved": "https://registry.npmjs.org/@redocly/theme/-/theme-0.68.0-next.9.tgz",
+      "integrity": "sha512-A7C9bta6kAvA0+kiW939QfDAFAJQ0IYRE76KEyHBfDrhQapOgRX7eJq1PmOnbLHFSlOHj7G0w3wh0ZP4PnnLPg==",
       "license": "MIT",
       "dependencies": {
         "@redocly/config": "0.53.1",
@@ -3318,6 +3279,346 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/@uiw/codemirror-extensions-basic-setup": {
       "version": "4.25.11",
       "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.25.11.tgz",
@@ -3438,12 +3739,12 @@
       }
     },
     "node_modules/@xyflow/react": {
-      "version": "12.11.2",
-      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.11.2.tgz",
-      "integrity": "sha512-eLAlDWJfWnQEhJwGMjlWdAXO9eYllKpliUmPQlAmOLxz6mExXuzMVDUKLMquixgkrtmMFFtug3jGKmYYld12cA==",
+      "version": "12.11.3",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.11.3.tgz",
+      "integrity": "sha512-G3jogHz2GWUtIOkhavUGno2YzY9u6fILIJBttfsBendb0/HWB90JG+sOTAvlIMEwyvq9zgy9V9ZQSwyQjR5QzQ==",
       "license": "MIT",
       "dependencies": {
-        "@xyflow/system": "0.0.79",
+        "@xyflow/system": "0.0.80",
         "classcat": "^5.0.3",
         "zustand": "^4.4.0"
       },
@@ -3463,9 +3764,9 @@
       }
     },
     "node_modules/@xyflow/system": {
-      "version": "0.0.79",
-      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.79.tgz",
-      "integrity": "sha512-czLyOh91NF0hIzbNzwi8I6GlqG23BHh2435OddfI6uiaLH3xdrdygO93gqgH1Bv9mhy8XPFQJOBn1FTq4LvEWA==",
+      "version": "0.0.80",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.80.tgz",
+      "integrity": "sha512-ywc3ZqG91brzWrH1WlwMdIX4goOfrpBy6AbLdVSaof/Xx9l138ijIKRExM6EkMro2F+OImGmSiA/WKcXvKVcfA==",
       "license": "MIT",
       "dependencies": {
         "@types/d3-drag": "^3.0.7",
@@ -5431,6 +5732,22 @@
         "pako": "^2.1.0"
       }
     },
+    "node_modules/fast-png/node_modules/pako": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.2.0.tgz",
+      "integrity": "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
@@ -6056,9 +6373,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.34",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.34.tgz",
-      "integrity": "sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -6579,9 +6896,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -6653,13 +6970,14 @@
       }
     },
     "node_modules/json-schema-to-ts": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
-      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-2.7.2.tgz",
+      "integrity": "sha512-R1JfqKqbBR4qE8UyBR56Ms30LL62/nlhoz+1UkfI/VE7p54Awu919FZ6ZUPG8zIa3XB65usPJgr1ONVncUGSaQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
-        "ts-algebra": "^2.0.0"
+        "@types/json-schema": "^7.0.9",
+        "ts-algebra": "^1.2.0"
       },
       "engines": {
         "node": ">=16"
@@ -6731,12 +7049,6 @@
         "readable-stream": "~2.3.6",
         "setimmediate": "^1.0.5"
       }
-    },
-    "node_modules/jszip/node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "license": "(MIT AND Zlib)"
     },
     "node_modules/katex": {
       "version": "0.16.47",
@@ -7126,15 +7438,15 @@
       }
     },
     "node_modules/marked": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
-      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 12"
       }
     },
     "node_modules/math-intrinsics": {
@@ -7826,6 +8138,19 @@
         "marked": "14.0.0"
       }
     },
+    "node_modules/monaco-editor/node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/motion-dom": {
       "version": "12.43.0",
       "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.43.0.tgz",
@@ -7857,9 +8182,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.9.tgz",
-      "integrity": "sha512-Aooyr6MXU6HpvvWXKoVoXwKMs/KyVakWwg7xQfv5/S/RIgJMy0Ifa45H9qqYy7pTCszrHzP21Uk4PZq2HpEM8Q==",
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
+      "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
       "funding": [
         {
           "type": "github",
@@ -8145,19 +8470,9 @@
       }
     },
     "node_modules/pako": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-2.2.0.tgz",
-      "integrity": "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
@@ -9796,9 +10111,9 @@
       }
     },
     "node_modules/ts-algebra": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
-      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-1.2.2.tgz",
+      "integrity": "sha512-kloPhf1hq3JbCPOTYoOWDKxebWjNb2o/LKnNfkWhxVVisFFmMJPPdJeGoGmM+iRLyoXAR61e08Pb+vUXINg8aA==",
       "license": "MIT"
     },
     "node_modules/ts-node": {

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   "author": "team@redocly.com",
   "license": "UNLICENSED",
   "dependencies": {
-    "@redocly/marketing-pages": "0.2.24",
-    "@redocly/realm": "0.136.0-next.13",
+    "@redocly/marketing-pages": "0.2.25",
+    "@redocly/realm": "0.136.0-next.15",
     "buffer": "^6.0.3",
     "highlight-words-core": "^1.2.3",
     "path": "^0.12.7",
@@ -40,6 +40,6 @@
     "js-cookie@<3.0.7": "3.0.7",
     "markdown-it@<14.2.0": "14.3.0",
     "dompurify@<3.4.13": "3.4.13",
-    "@redocly/realm": "0.136.0-next.13"
+    "@redocly/realm": "0.136.0-next.15"
   }
 }


### PR DESCRIPTION
## What/Why/How?
Bump `realm` to latest version - `0.136.0-next.15`
Bump `marketing-pages` to latest version - `0.2.25`

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
