### PR TITLE
chore: bump realm and marketing-pages versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "license": "UNLICENSED",
       "dependencies": {
-        "@redocly/marketing-pages": "0.2.25",
-        "@redocly/realm": "0.136.0-next.15",
+        "@redocly/marketing-pages": "^0.2.26",
+        "@redocly/realm": "0.136.0",
         "buffer": "^6.0.3",
         "highlight-words-core": "^1.2.3",
         "path": "^0.12.7",
@@ -2158,9 +2158,9 @@
       }
     },
     "node_modules/@redocly/api-docs": {
-      "version": "0.1.0-next.7",
-      "resolved": "https://registry.npmjs.org/@redocly/api-docs/-/api-docs-0.1.0-next.7.tgz",
-      "integrity": "sha512-hkxpKTYfHRyG0kFo7Wf7nKTBHTJwYkQ5UefWX1tSsePkjT+QD1/D7VKDjLzZSmlmgY9UXaHRDxz1+oKv/kAZDQ==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@redocly/api-docs/-/api-docs-0.1.0.tgz",
+      "integrity": "sha512-I06y1I0OR39Zj1iAkQz/ZNYKSXd/ZN26cDenRFdmJ28vUUjVcZWY4o23WLew0NdA8b1yXRZFNUkM++C6GkiTAA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@markdoc/markdoc": "0.5.2",
@@ -2168,8 +2168,8 @@
         "@redocly/config": "0.53.1",
         "@redocly/openapi-core": "2.45.0",
         "@redocly/redoc-opentelemetry": "0.2.2",
-        "@redocly/replay": "0.27.0-next.12",
-        "@redocly/theme": "^0.68.0-next.9",
+        "@redocly/replay": "0.27.0",
+        "@redocly/theme": "^0.68.0",
         "dompurify": "3.4.13",
         "fast-xml-parser": "5.7.3",
         "graphql": "16.14.2",
@@ -2193,16 +2193,16 @@
       }
     },
     "node_modules/@redocly/asyncapi-docs": {
-      "version": "1.13.0-next.13",
-      "resolved": "https://registry.npmjs.org/@redocly/asyncapi-docs/-/asyncapi-docs-1.13.0-next.13.tgz",
-      "integrity": "sha512-AGV0EC7TGfn7aT+3FU966zzNmfcp+RT7LTWbCNjO7vQEMiisFsynpa3NmNZU32IKoLuhiYcCeNsr4QKKElo+0g==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@redocly/asyncapi-docs/-/asyncapi-docs-1.13.0.tgz",
+      "integrity": "sha512-T+OtnsBK79w+9SyLcGxTJLFsYtJfZ2qqbOen7sAFiSFCtbKoPUJdvie5CYyS6cpQa1WpMzhuG2uMeab7WKV5DA==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@markdoc/markdoc": "0.5.2",
         "@redocly/config": "0.53.1",
-        "@redocly/openapi-docs": "3.24.0-next.13",
+        "@redocly/openapi-docs": "3.24.0",
         "@redocly/redoc-opentelemetry": "0.2.2",
-        "@redocly/theme": "0.68.0-next.9",
+        "@redocly/theme": "0.68.0",
         "jotai": "^2.11.1",
         "openapi-sampler": "^1.7.2",
         "react-router": "^8.3.0",
@@ -2223,20 +2223,20 @@
       }
     },
     "node_modules/@redocly/graphql-docs": {
-      "version": "1.13.0-next.13",
-      "resolved": "https://registry.npmjs.org/@redocly/graphql-docs/-/graphql-docs-1.13.0-next.13.tgz",
-      "integrity": "sha512-WwEPpk+FMFdbDD0ONcxssT/u3fcg2U4rN4f8B907zS/qhHs9yEKFuUp53vUqjxISXxFTyJA/0KcY0OqWQZzByA==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@redocly/graphql-docs/-/graphql-docs-1.13.0.tgz",
+      "integrity": "sha512-DEljQtehmFGdxfb1/hHqjji45d5f+ZKZOKSPzx93sbLmF0fB5ZyR3HHnEeHenN9l4UmwNbTKB4uGK+J0nCt1xw==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@redocly/config": "0.53.1",
-        "@redocly/openapi-docs": "3.24.0-next.13",
+        "@redocly/openapi-docs": "3.24.0",
         "@redocly/redoc-opentelemetry": "0.2.2",
         "deepmerge": "^4.2.2",
         "marked": "^4.0.15",
         "web-vitals": "3.3.1"
       },
       "peerDependencies": {
-        "@redocly/theme": "0.68.0-next.9",
+        "@redocly/theme": "0.68.0",
         "graphql": "16.14.2",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
@@ -2251,9 +2251,9 @@
       "license": "SEE LICENSE IN LICENSE"
     },
     "node_modules/@redocly/marketing-pages": {
-      "version": "0.2.25",
-      "resolved": "https://registry.npmjs.org/@redocly/marketing-pages/-/marketing-pages-0.2.25.tgz",
-      "integrity": "sha512-xkRa/tuE2BYgJmq9Y7+xT50vugW6OUOhRY9ezvoop6nog55uJgoTWAzzAaGvzVsYAyJrGPBit6/KElTRTZY9+g==",
+      "version": "0.2.26",
+      "resolved": "https://registry.npmjs.org/@redocly/marketing-pages/-/marketing-pages-0.2.26.tgz",
+      "integrity": "sha512-nrtcdcVNnIUifP+qtJ1sAMEW2iEgBa5nOWutwwy+raluNlKK1667QGztziChaKSZ0rjFu3DxKOr1y+Rfpu7GiQ==",
       "license": "UNLICENSED",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.1",
@@ -2293,8 +2293,8 @@
         "ulid": "^2.3.0"
       },
       "peerDependencies": {
-        "@redocly/realm": "0.136.0-next.15",
-        "@redocly/theme": "0.68.0-next.9",
+        "@redocly/realm": "0.136.0",
+        "@redocly/theme": "0.68.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "styled-components": "^6.4.2"
@@ -2336,9 +2336,9 @@
       "license": "MIT"
     },
     "node_modules/@redocly/mock-server": {
-      "version": "0.10.0-next.5",
-      "resolved": "https://registry.npmjs.org/@redocly/mock-server/-/mock-server-0.10.0-next.5.tgz",
-      "integrity": "sha512-WWfy9WSWxANOPhb1K7vO2Bsr57c6ir/uJl0HYonLXCN9vDzbLwEmoc1Ji2DC881UoocTIWfM2CMR0mkqIUAfXg==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@redocly/mock-server/-/mock-server-0.10.0.tgz",
+      "integrity": "sha512-162k659ADkMva40DJ7MdLZ3ic4ohWr2gkIw9hdEk6KxWKP1zfnbTmZGLiSC1DSFDWKctRmFWJ/7Tj8hqtsSbJg==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@redocly/ajv": "8.18.0",
@@ -2432,9 +2432,9 @@
       }
     },
     "node_modules/@redocly/openapi-docs": {
-      "version": "3.24.0-next.13",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-docs/-/openapi-docs-3.24.0-next.13.tgz",
-      "integrity": "sha512-ZJFmSTOc1Rst1BJIQAz+BwyKDu9Y5iYEbTJYKIiTW1wz2Wu0E/SKZ4p9ze9eoD8xZdHjUTQ8T/upWe8SM5wPXw==",
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-docs/-/openapi-docs-3.24.0.tgz",
+      "integrity": "sha512-ZwfiROo8AIyNFO2zlOOLx2wOoTLzF/CW8An34BSXEsDuDGLUCtq0G5QdXF71doPP5acbS8Ozg3PLCyZFV96QlA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@babel/core": "7.29.7",
@@ -2442,7 +2442,7 @@
         "@redocly/config": "0.53.1",
         "@redocly/openapi-core": "2.45.0",
         "@redocly/redoc-opentelemetry": "0.2.2",
-        "@redocly/replay": "0.27.0-next.12",
+        "@redocly/replay": "0.27.0",
         "deepmerge": "^4.2.2",
         "dompurify": "3.4.13",
         "fast-deep-equal": "^3.1.3",
@@ -2487,21 +2487,34 @@
         "@redocly/openapi-core": "2.45.0"
       }
     },
+    "node_modules/@redocly/portal-legacy-ui": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@redocly/portal-legacy-ui/-/portal-legacy-ui-0.19.0.tgz",
+      "integrity": "sha512-p+VzHDkaMzehFh+WsDOzHvhTl9eaSHuuMgJViXpXV9yZnaHxHj2RQ9X4IG1hncCLPaVvHROWJAmpsYwoQdfQXg==",
+      "license": "SEE LICENSE IN LICENSE",
+      "peerDependencies": {
+        "highlight-words-core": "^1.2.2",
+        "react": "^19.2.7",
+        "react-router": "^8.3.0",
+        "styled-components": "^4.1.1 || ^5.3.11 || ^6.0.0",
+        "styled-system": "^5.1.5"
+      }
+    },
     "node_modules/@redocly/portal-plugin-mock-server": {
-      "version": "0.21.0-next.13",
-      "resolved": "https://registry.npmjs.org/@redocly/portal-plugin-mock-server/-/portal-plugin-mock-server-0.21.0-next.13.tgz",
-      "integrity": "sha512-CgxS5LxWau8d5+zpOwOoij7w/nV/tBBlVpVCT7P3AYGrviBQXl12YTGYBMrxoL71zIx0Jvs+01La4aPBUGVnBg==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@redocly/portal-plugin-mock-server/-/portal-plugin-mock-server-0.21.0.tgz",
+      "integrity": "sha512-BbsjsBbtOv5anXUFQNJHpKqoyG1lAwBmyLp6taSfSUmN9EEDg5fiVe9EnjBwZungRqHU4GbVJJ15q5jRs6Oh2g==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@redocly/config": "0.53.1",
-        "@redocly/mock-server": "0.10.0-next.5",
-        "@redocly/openapi-docs": "3.24.0-next.13"
+        "@redocly/mock-server": "0.10.0",
+        "@redocly/openapi-docs": "3.24.0"
       }
     },
     "node_modules/@redocly/realm": {
-      "version": "0.136.0-next.15",
-      "resolved": "https://registry.npmjs.org/@redocly/realm/-/realm-0.136.0-next.15.tgz",
-      "integrity": "sha512-egvy4EOFtP6y1mtR0apuz7Zj1UhupIzWOcczP5jJGOs58cZqymPdsomToeeeyfECrhB3efbaa+CQXE4Ej3SR1g==",
+      "version": "0.136.0",
+      "resolved": "https://registry.npmjs.org/@redocly/realm/-/realm-0.136.0.tgz",
+      "integrity": "sha512-XBLxZAqvdW3yfnXnGsvN29N6Zxt/ej5nJfX3WqxXwcULUDYRnLB66kX8Q6B8kwdP1RMliATUyyQ4cmWkFRTHhw==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@babel/core": "7.29.7",
@@ -2523,16 +2536,16 @@
         "@opentelemetry/sdk-trace-web": "2.8.0",
         "@opentelemetry/semantic-conventions": "1.40.0",
         "@redocly/ajv": "8.18.0",
-        "@redocly/api-docs": "0.1.0-next.7",
-        "@redocly/asyncapi-docs": "1.13.0-next.13",
+        "@redocly/api-docs": "0.1.0",
+        "@redocly/asyncapi-docs": "1.13.0",
         "@redocly/config": "0.53.1",
-        "@redocly/graphql-docs": "1.13.0-next.13",
+        "@redocly/graphql-docs": "1.13.0",
         "@redocly/openapi-core": "2.45.0",
-        "@redocly/openapi-docs": "3.24.0-next.13",
-        "@redocly/portal-legacy-ui": "0.19.0-next.0",
-        "@redocly/portal-plugin-mock-server": "0.21.0-next.13",
-        "@redocly/realm-asyncapi-sdk": "0.14.0-next.4",
-        "@redocly/theme": "0.68.0-next.9",
+        "@redocly/openapi-docs": "3.24.0",
+        "@redocly/portal-legacy-ui": "0.19.0",
+        "@redocly/portal-plugin-mock-server": "0.21.0",
+        "@redocly/realm-asyncapi-sdk": "0.14.0",
+        "@redocly/theme": "0.68.0",
         "@shikijs/transformers": "3.21.0",
         "@tanstack/react-query": "5.62.3",
         "@tanstack/react-table": "8.21.3",
@@ -2606,9 +2619,9 @@
       }
     },
     "node_modules/@redocly/realm-asyncapi-sdk": {
-      "version": "0.14.0-next.4",
-      "resolved": "https://registry.npmjs.org/@redocly/realm-asyncapi-sdk/-/realm-asyncapi-sdk-0.14.0-next.4.tgz",
-      "integrity": "sha512-XnRys0ht/axkQhcuWZAPVc2yiVh65zN9w5QTXVkmoLwBXfd20cjklHBexDXZi+a6JEmiw94he0Fv5Se+GqU2jw==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@redocly/realm-asyncapi-sdk/-/realm-asyncapi-sdk-0.14.0.tgz",
+      "integrity": "sha512-GaZxKZ8kNiZ7hxcYq3rnMfY7LTRVCs2iKkO+CWeKJ8yPtqYD+7lKcxWMvVV8onW/rElm3cviGYc0Z/IeGn6Xeg==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "safe-stable-stringify": "2.5.0"
@@ -2628,19 +2641,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@redocly/realm/node_modules/@redocly/portal-legacy-ui": {
-      "version": "0.19.0-next.0",
-      "resolved": "https://registry.npmjs.org/@redocly/portal-legacy-ui/-/portal-legacy-ui-0.19.0-next.0.tgz",
-      "integrity": "sha512-BQBr0JlDKJmtMmNEXusz4c6BDQVJTygQjFCdP2xpj9qFj5f94MAQEEvvwaZ95ig9wI3MGCyhPbjO4ZnjDpP4+Q==",
-      "license": "SEE LICENSE IN LICENSE",
-      "peerDependencies": {
-        "highlight-words-core": "^1.2.2",
-        "react": "^19.2.7",
-        "react-router": "^8.3.0",
-        "styled-components": "^4.1.1 || ^5.3.11 || ^6.0.0",
-        "styled-system": "^5.1.5"
       }
     },
     "node_modules/@redocly/realm/node_modules/colorette": {
@@ -2668,11 +2668,11 @@
       "license": "MIT"
     },
     "node_modules/@redocly/replay": {
-      "version": "0.27.0-next.12",
-      "resolved": "https://registry.npmjs.org/@redocly/replay/-/replay-0.27.0-next.12.tgz",
-      "integrity": "sha512-A1MNqT+qWN9IM2uAhvNqvUTBTU2ryenudgMv4TDMV9mUxa+jNqa3tHsYB5lSsjvMeY/Lr4A9YLJLXAf+yR/dyg==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@redocly/replay/-/replay-0.27.0.tgz",
+      "integrity": "sha512-CQYCnBXTybcKWSYGGgyH4NrMtWi9xy6hy6Q9NO5zWJQh3uVys/0VXxc7/mbEqdr1ieat1lAV97v6KPxQENXMAg==",
       "peerDependencies": {
-        "@redocly/theme": "0.68.0-next.9",
+        "@redocly/theme": "0.68.0",
         "@tanstack/react-query": "5.62.3",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
@@ -2681,9 +2681,9 @@
       }
     },
     "node_modules/@redocly/theme": {
-      "version": "0.68.0-next.9",
-      "resolved": "https://registry.npmjs.org/@redocly/theme/-/theme-0.68.0-next.9.tgz",
-      "integrity": "sha512-A7C9bta6kAvA0+kiW939QfDAFAJQ0IYRE76KEyHBfDrhQapOgRX7eJq1PmOnbLHFSlOHj7G0w3wh0ZP4PnnLPg==",
+      "version": "0.68.0",
+      "resolved": "https://registry.npmjs.org/@redocly/theme/-/theme-0.68.0.tgz",
+      "integrity": "sha512-O1pJWKgcqlaYppsFL2iOewyfADUwKNeulsfv2yePaAbQHUaomNq0QIXQGqwsBjsUw+EC2grQW5Lcu9J3erkwnQ==",
       "license": "MIT",
       "dependencies": {
         "@redocly/config": "0.53.1",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   "author": "team@redocly.com",
   "license": "UNLICENSED",
   "dependencies": {
-    "@redocly/marketing-pages": "0.2.25",
-    "@redocly/realm": "0.136.0-next.15",
+    "@redocly/marketing-pages": "^0.2.26",
+    "@redocly/realm": "0.136.0",
     "buffer": "^6.0.3",
     "highlight-words-core": "^1.2.3",
     "path": "^0.12.7",
@@ -40,6 +40,6 @@
     "js-cookie@<3.0.7": "3.0.7",
     "markdown-it@<14.2.0": "14.3.0",
     "dompurify@<3.4.13": "3.4.13",
-    "@redocly/realm": "0.136.0-next.15"
+    "@redocly/realm": "0.136.0"
   }
 }


### PR DESCRIPTION
## What/Why/How?
Bump `realm` to latest version - `0.136.0`
Bump `marketing-pages` to latest version - `0.2.26`
## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
