### PR TITLE
Add: Use AI to decide which API endpoints to monitor first

### DIFF
--- a/learn/ai-for-docs/ai-decide-which-api-endpoints-to-monitor-first.md
+++ b/learn/ai-for-docs/ai-decide-which-api-endpoints-to-monitor-first.md
@@ -8,115 +8,94 @@ seo:
 
 ## Key takeaways
 
-- Monitor a few high-risk Arazzo workflows first. Do not treat every OpenAPI path as a required check.
-- Rank with OpenAPI plus traffic hints and support tickets, then discard any path the spec cannot support.
-- Put the ranked list on a Respect schedule (CLI `--workflow`, then hosted jobs and alerts) so the ranking is not a slide.
-- Re-rank after launches, incidents, and spec changes so coverage follows the product.
+- Monitoring every endpoint equally tends to produce thin, shallow coverage everywhere and often leaves out the workflows that break in production, like checkout or auth refresh flows.
+- A useful AI ranking needs more than the OpenAPI description alone. Traffic or usage hints, support ticket themes, and breaking-change history all matter too.
+- AI has no visibility into real production traffic or incidents unless you feed it that context, and it tends to overweight endpoints that sound important over the ones that see heavy use.
+- Ranked priorities become real coverage only once they are turned into Arazzo workflows and scheduled in Respect, rather than left as a one-time list.
+- Respect scorecards and reports give the evidence needed to revisit and re-rank monitoring priorities as the API evolves.
 
-Most teams start API monitoring as if the OpenAPI file were a checklist: every path gets a ping, and coverage is the percentage of operations that return something. That score feels complete, and it is a poor predictor of whether customers can still complete a job. A green check on `GET /items/{id}` does not tell you whether login still issues a token, whether create still returns the fields the next call needs, or whether [a 200 OK can still drop a required field](https://redocly.com/blog/api-contract-testing-arazzo).
+Monitoring every endpoint equally sounds like the responsible choice, but in practice it is a habit that most docs and platform teams fall into at some point. An API with two hundred operations does not need two hundred equally weighted monitors, and treating every path as equally critical tends to produce either an unmanageable monitoring bill or, more often, a shallow set of checks that never quite gets finished. The pattern shows up across the industry in a familiar shape: a team commits to "full coverage," starts with the easy endpoints, and lets the checkout flow, the auth refresh path, or the webhook callback (the parts that break in production and generate support tickets) get monitored last, if at all.
 
-The useful first question is not "which endpoints are we missing?" It is "which short sequences, if they broke, would page support or stop a partner?" AI is good at ranking those sequences when you give it the spec plus a little operational context. Deterministic monitors then run the ranked list. The ranking is a draft; the schedule is the decision.
+This article works through why that happens, what signals help an AI make a defensible ranking instead of a guess, and how Respect turns that ranking into something enforced rather than merely documented.
 
-## Why covering every endpoint fails
+## Why "monitor everything" fails in practice
 
-Exhaustive path monitors fail in three predictable ways. They produce noise: low-traffic admin routes and experimental stubs fail for reasons nobody will fix this week, so on-call learns to mute the channel. They miss the failures that matter: checkout is not one operation, and a token that still validates on a health path can still be rejected on the write that follows. They stall rollout, because a program that must cover hundreds of operations never ships the first ten.
+Coverage spread evenly across every endpoint ends up thin everywhere. Docs orgs and platform teams that try to monitor everything at once usually write the simplest checks first, since those are the fastest to author, and simple checks tend to catch only simple problems. The failures that matter most, like [a subtle change in the response format that wasn't caught](https://redocly.com/blog/api-contract-testing-arazzo) by a basic status-code check, tend to live in the workflows nobody prioritized: multi-step purchase flows, pagination edge cases, or endpoints chained together in a way no single-request test would ever reveal.
 
-Uptime-style checks make the problem worse. They answer whether a server responded, not whether the response still matches the description you publish. Contract-aware monitoring is the opposite bet: assert [status codes, content types, schemas, and success criteria](https://redocly.com/docs/realm/reunite/project/respect-monitoring) on the flows customers run, and accept that many operations will have no dedicated monitor until they earn one.
+There is also a sequencing problem worth naming. Most real API usage is not a single endpoint call but a sequence: authenticate, create a resource, poll for status, then fetch a result. An Arazzo workflow captures exactly that kind of sequence, which is why monitoring priority is usually a question about workflows rather than isolated endpoints. Ranking single endpoints on their own misses the fact that a workflow can fail even when each of its individual steps still passes in isolation.
 
-Treat "every endpoint" as a backlog, not a launch criterion. The first slice should be small enough that a failure still has an owner.
+## What signals to feed an AI for a useful ranking
 
-## Rank workflows, not isolated paths
+An AI can produce a reasonable first-pass ranking, but only if it has more to work with than the OpenAPI description alone. A few sources tend to matter most:
 
-What is worth monitoring first is usually a workflow: authenticate, create a resource, read it back, maybe cancel. That is [sequences of operations rather than isolated paths](https://redocly.com/learn/arazzo/what-is-arazzo), which is what Arazzo is for. Ranking `POST /orders` without the token step and the subsequent GET will either false-alarm on auth setup or miss a break that only appears when steps share data.
+- The OpenAPI description itself, since it tells the AI what operations exist, which ones are marked deprecated or experimental, and which ones share tags or resource paths that suggest a workflow.
+- Traffic or usage hints, even rough ones, such as which endpoints appear most often in API gateway logs, analytics dashboards, or billing data.
+- Support ticket themes, since recurring complaints about a particular endpoint or flow are a strong signal that something there needs closer watching.
+- Breaking-change history, since endpoints that have changed shape more than once in the past year are more likely to drift again.
 
-Ask AI to propose Arazzo-shaped flows, not a sorted table of paths. A good proposal names the job ("partner creates an order and fetches its status"), the operations in order, and what must be true after each step. A bad proposal is a restated tag list from the spec ("all `/billing/*` routes, high priority") with no success criteria and no evidence.
+None of these signals is enough on its own. Traffic data without support context might rank a high-volume but stable endpoint above a lower-volume one that keeps generating tickets. Support tickets without traffic context might overweight a rarely used endpoint that happens to be noisy. Feeding the AI all four together gives it enough context to reason about tradeoffs instead of optimizing for a single metric.
 
-If the model returns an operation that is not in the OpenAPI file, drop it. Invented paths are how ranking sessions turn into fiction. The spec is the allowlist; traffic and tickets are only weights on top of it.
+## An example prompt structure for ranking endpoints and workflows
 
-## Inputs AI needs to rank well
+A useful prompt gives the AI a role, the inputs it should weigh, and the output shape you want back.
 
-Give the model four kinds of input, and withhold the rest.
+### Step-by-step: building the prompt
 
-- OpenAPI, or a slice. A domain tags file or a single versioned description is enough. Whole-org dumps bury the signal and invite hallucinated servers.
-- Traffic or SLI hints. Even coarse notes help: "80% of 5xx last month were `POST /checkout`", "this partner integration is 30% of production writes." You do not need a perfect analytics export.
-- Support tickets and incident titles. Phrases like "example returns 404" or "pagination changed" often point at workflows docs already claim to cover.
-- Known revenue or partner paths. List the two or three jobs the business cannot pause, even if they are not the noisiest in logs.
+1. State the goal: ask the AI to rank endpoints and workflows by monitoring priority, not to describe the API generally.
+2. Attach the OpenAPI description so the AI can see structure, tags, and any existing deprecation or stability markers.
+3. Summarize traffic in plain language, such as "the top five endpoints by request volume last quarter are X, Y, Z."
+4. Summarize support themes, such as "the three most common ticket categories in the last two months relate to pagination, webhook retries, and refund status."
+5. Ask for a ranked list grouped by workflow where relevant, with a one-line justification for each item and an explicit note on which signal drove that ranking.
 
-Do not paste secrets, full HAR dumps, or customer payloads. Summarize: method, path, status, and the field that surprised you. If tickets mention [holes in multi-step stories](https://redocly.com/learn/ai-for-docs/ai-find-gaps-documentation-coverage), include the job name ("create subscription after OAuth") rather than the entire guide.
+> Example prompt: "Here is our OpenAPI description, a summary of our top-trafficked endpoints, and a list of recurring support ticket themes from the last quarter. Rank the endpoints and multi-step workflows we should monitor first, grouping related calls into workflows where it makes sense. For each item, explain in one sentence which signal, traffic, support history, or breaking-change history, drove the ranking."
 
-When the spec and the tickets disagree, say so in the prompt. "Tickets say clients send `Idempotency-Key` on POST /orders; the spec does not document that header" is a ranking input. It is also a docs or spec task, not a reason to monitor an undocumented operation until someone owns the contract.
+Treat the output from a prompt like this as a starting draft rather than a final decision. It still needs a person to check it against context the AI cannot see.
 
-## A ranking prompt that produces a schedule
+## Where AI gets this wrong
 
-Ask for a short ordered list you can paste into an Arazzo file, not a rewritten specification. Constrain the output: at most seven workflows, each with a name, steps tied to `operationId`s, success criteria, and a one-line reason that cites the inputs you provided.
+AI has no visibility into your production traffic, incident history, or support queue unless you paste that context in directly, and even then it only sees a summary rather than the full picture. Left without that grounding, an AI will tend to rank endpoints by how important they sound in the spec, favoring anything labeled "payment" or "account" over endpoints that get hit constantly but sound mundane, like a status-check or list operation. That bias toward important-sounding names over heavily used paths is worth watching for whenever you review an AI-generated ranking, since it is one of the more common ways these lists go wrong.
 
-```text
-You are ranking API workflows to monitor first. Use only operations
-that appear in the attached OpenAPI. Do not invent paths, servers,
-or fields.
+The safer posture is to treat the AI's ranking as a draft for someone familiar with the traffic and support data to confirm or adjust, rather than as a final decision.
 
-Inputs: OpenAPI (attached). Traffic notes: {paste}. Support themes:
-{paste}. Business-critical jobs: {paste}.
+## Turning the ranked list into Arazzo workflows scheduled in Respect
 
-Return at most 7 workflows. For each:
-- workflowId (kebab-case)
-- steps: method + path or operationId, in order
-- success criteria (status and one schema or field check per step)
-- why it outranks the rest (cite a ticket theme or traffic hint)
-- what we are explicitly not covering yet
+Once a ranked list exists, the next step is making it operational instead of leaving it as a document nobody rechecks.
 
-If an input mentions a path that is not in the spec, list it under
-"needs spec decision" instead of a workflow.
-```
+### Step-by-step: from ranking to scheduled coverage
 
-Read the result like a test plan. Merge duplicates. Reject anything whose steps cannot be executed with the security schemes you use in staging. If the model ranks an internal debug route above checkout because a ticket mentioned it once, put that ticket on a docs list and keep checkout first.
+1. For each high-priority workflow, use Redocly CLI to [auto-generate an Arazzo description from an OpenAPI description](https://redocly.com/docs/respect/commands/generate-arazzo) as a starting point rather than writing the workflow steps by hand.
+2. Review the generated steps against the sequence real users actually follow, adjusting call order and parameters where the AI's guess does not match production behavior.
+3. Add success criteria so Respect knows what a passing run looks like, since Respect [checks your API responses match what the OpenAPI description says](https://redocly.com/docs/respect) and needs explicit assertions to do that reliably.
+4. Schedule the workflow in Respect for [scheduled monitoring of critical paths](https://redocly.com/respect), so the highest-priority items run automatically instead of depending on someone remembering to test them.
 
-The output of this step is an ordered backlog, not a promise that the first item is the only risk. You are choosing where limited monitor budget goes this month.
+This is the clearest line between AI's role and Respect's role. AI brings judgment, synthesizing traffic, support, and spec signals into a ranked, human-reviewable list, while Respect brings the deterministic part. It [autogenerates tests from OpenAPI](https://redocly.com/docs/respect/what-is-respect) and then runs those tests on a schedule, catching [unexpected status codes, incorrect content types, and schema mismatches](https://redocly.com/blog/respect) without needing a person to remember to check. Reviewing [common Respect use cases](https://redocly.com/docs/respect/use-cases) and reading more about [testing API workflows](https://redocly.com/learn/arazzo/testing-arazzo-workflows) or [an Arazzo workflow](https://redocly.com/learn/arazzo/what-is-arazzo) helps
+confirm the generated steps match the shape Respect expects before you schedule anything.
 
-## Make the list operational in Respect
+## Using Respect scorecards and reports to revisit priorities
 
-A ranking that stays in a doc is a brainstorm. Put the first slice in an Arazzo file in the same repository as the OpenAPI description, then [run named workflows from the Arazzo file](https://redocly.com/docs/cli/commands/respect) with the Respect CLI `--workflow` option so you are not executing every flow while the list is still in draft.
-
-[Run the same Arazzo file in CI first](https://redocly.com/respect-cli). A workflow that cannot pass against staging with a non-production token is not ready for a hosted schedule. Fix the description, the environment, or the assertions before you page anyone.
-
-When the first two or three workflows are green in CI, [schedule those workflows on an interval](https://redocly.com/docs/realm/reunite/project/respect-monitoring/configure-respect-monitoring) in `redocly.yaml` (`schedule` for ongoing checks, `build` if you also want them on project builds). Start with a conservative interval on production and a tighter one on staging. Subscribe alerts only for the workflows in the first slice, so the channel stays tied to ranked risk.
-
-As the list changes, [archive workflows that are no longer in the first slice](https://redocly.com/docs/realm/reunite/project/respect-monitoring/manage-respect-monitoring) instead of leaving retired flows on the dashboard. Archived does not mean forgotten; it means the on-call view matches the current ranking.
-
-## Re-rank when the surface changes
-
-Re-run the ranking when you ship a new public job, after an incident that surprised you, and when a spec diff adds or removes operations in a tagged domain. The prompt can take the previous workflow list as an extra input: "keep these unless the new spec makes them impossible, and propose at most two additions."
-
-Do not freeze the first brainstorm for a year. Coverage that never moves is how exhaustive monitoring sneaks back in under a new name. When alerts start firing, [turn later alerts into doc or spec fixes](https://redocly.com/learn/ai-for-docs/ai-detect-drift-docs-live-api) rather than adding more paths in a panic. New monitors should still win a rank against the current slice.
-
-The habit is small and repeatable: rank a few workflows from the contract plus operational hints, schedule only those, and re-rank when the product changes. AI drafts the ordered list. Respect and CI make the list true.
+A ranking made once tends to age quickly, since traffic patterns shift, new endpoints ship, and old ones get deprecated. The [reports on scheduled Respect runs](https://redocly.com/docs/realm/reunite/project/respect-monitoring) give a running record of which workflows are passing, which are flaky, and which have gone untouched, and that record is useful raw material to feed back into another round of AI-assisted ranking every quarter or so. Teams that also want to catch [detecting drift between docs and a live API](https://redocly.com/learn/ai-for-docs/ai-detect-drift-docs-live-api) or start by [finding gaps in documentation coverage](https://redocly.com/learn/ai-for-docs/ai-find-gaps-documentation-coverage) will find this the same underlying discipline at work:
+revisit the ranking regularly instead of treating it as a one-time exercise, and let scheduled evidence, rather than intuition, decide what moves up the list.
 
 ## FAQs
 
-### Why not monitor every operation in the OpenAPI file?
+**Why shouldn't I just monitor every endpoint to be safe?**
+Monitoring every endpoint equally tends to produce shallow coverage everywhere rather than strong coverage anywhere, since teams usually write the simplest checks first and leave the workflows that break in production, like checkout or auth refresh, for later or never. A ranked, prioritized approach protects the paths that matter most instead of spreading effort evenly across everything.
 
-Because exhaustive path lists create mute-able noise, miss multi-step failures, and delay the first useful schedule. Rank [sequences of operations rather than isolated paths](https://redocly.com/learn/arazzo/what-is-arazzo), then add operations only when they earn a place against that slice.
+**What information does AI need to rank endpoints usefully?**
+An AI needs more than the OpenAPI description alone. It benefits from traffic or usage hints, support ticket themes, and breaking-change history, since each signal covers a blind spot the others miss. Feeding all four together helps the AI reason about tradeoffs instead of optimizing for a single metric.
 
-### What inputs should we give an AI besides the spec?
+**Should I monitor individual endpoints or whole workflows?**
+Most real API usage happens as a sequence of calls, like authenticating, creating a resource, and polling for status, so monitoring priority is usually a question about workflows rather than single endpoints. [An Arazzo workflow](https://redocly.com/learn/arazzo/what-is-arazzo) captures that sequence, and a workflow can fail even when each individual step still passes on its own.
 
-Traffic or SLI hints, support-ticket themes, and the two or three jobs the business cannot pause. Withhold secrets and full payload dumps. If tickets describe [holes in multi-step stories](https://redocly.com/learn/ai-for-docs/ai-find-gaps-documentation-coverage), pass the job name, not the entire guide.
+**What mistakes does AI make when ranking monitoring priorities?**
+Without visibility into real production traffic or support history, AI tends to rank endpoints by how important they sound in the spec, favoring names like "payment" or "account" over endpoints that get used constantly but sound mundane. Treat any AI-generated ranking as a draft for someone familiar with the real traffic and support data to confirm or adjust.
 
-### How is a workflow different from an endpoint for monitoring?
+**How do I turn an AI-generated ranking into something enforced rather than just documented?**
+For each high-priority workflow, you can [auto-generate an Arazzo description from an OpenAPI description](https://redocly.com/docs/respect/commands/generate-arazzo), review the generated steps against real usage, add success criteria, and schedule the workflow for [scheduled monitoring of critical paths](https://redocly.com/respect). That turns a one-time ranking into coverage that runs automatically.
 
-A workflow is an ordered job (authenticate, create, read) that shares data across calls. An endpoint monitor on a single GET can stay green while the POST that supplies its id has already broken.
-
-### How do we stop AI inventing undocumented paths?
-
-State that the OpenAPI file is an allowlist, and move anything the model invents into a "needs spec decision" list. Do not schedule a monitor for an undocumented operation until someone owns the contract.
-
-### When should CI workflows move to hosted monitoring?
-
-After it passes in CI against staging with non-production credentials. Then [schedule those workflows on an interval](https://redocly.com/docs/realm/reunite/project/respect-monitoring/configure-respect-monitoring) and subscribe alerts only for that first slice.
-
-### How often should we re-rank the monitor list?
-
-After a new public job, after an incident that surprised you, and when a spec diff changes a tagged domain. Re-ranking is how the list stays a decision instead of a frozen brainstorm.
+**How do I keep a monitoring priority list up to date as the API changes?**
+The [reports on scheduled Respect runs](https://redocly.com/docs/realm/reunite/project/respect-monitoring) show which workflows are passing, flaky, or untouched, and that record is useful input for another round of AI-assisted ranking every quarter or so. Revisiting priorities regularly, rather than treating the first ranking as final, keeps monitoring aligned with how the API actually evolves.
 
 ## How Redocly can help
 
-Respect is built for [scheduled monitoring of the paths that matter first](https://redocly.com/respect): Arazzo workflows on an interval, with alerts when those critical sequences stop matching the OpenAPI description, so a ranked list becomes coverage instead of a slide.
+Deciding what to monitor first only matters if the decision holds up over time, and that is the gap Respect is built to close. Once an AI-assisted ranking points to the workflows that matter most, Respect turns that list into [scheduled monitoring of critical paths](https://redocly.com/respect), running the checks automatically and reporting back so the prioritization stays current instead of fading into a slide deck nobody revisits.

--- a/learn/ai-for-docs/ai-decide-which-api-endpoints-to-monitor-first.md
+++ b/learn/ai-for-docs/ai-decide-which-api-endpoints-to-monitor-first.md
@@ -1,0 +1,122 @@
+---
+seo:
+ title: Use AI to decide which API endpoints to monitor first
+ description: Rank Arazzo workflows with AI from OpenAPI, traffic hints, and support tickets, then schedule that first slice in Respect instead of monitoring every path.
+---
+
+# Use AI to decide which API endpoints to monitor first
+
+## Key takeaways
+
+- Monitor a few high-risk Arazzo workflows first. Do not treat every OpenAPI path as a required check.
+- Rank with OpenAPI plus traffic hints and support tickets, then discard any path the spec cannot support.
+- Put the ranked list on a Respect schedule (CLI `--workflow`, then hosted jobs and alerts) so the ranking is not a slide.
+- Re-rank after launches, incidents, and spec changes so coverage follows the product.
+
+Most teams start API monitoring as if the OpenAPI file were a checklist: every path gets a ping, and coverage is the percentage of operations that return something. That score feels complete, and it is a poor predictor of whether customers can still complete a job. A green check on `GET /items/{id}` does not tell you whether login still issues a token, whether create still returns the fields the next call needs, or whether [a 200 OK can still drop a required field](https://redocly.com/blog/api-contract-testing-arazzo).
+
+The useful first question is not "which endpoints are we missing?" It is "which short sequences, if they broke, would page support or stop a partner?" AI is good at ranking those sequences when you give it the spec plus a little operational context. Deterministic monitors then run the ranked list. The ranking is a draft; the schedule is the decision.
+
+## Why covering every endpoint fails
+
+Exhaustive path monitors fail in three predictable ways. They produce noise: low-traffic admin routes and experimental stubs fail for reasons nobody will fix this week, so on-call learns to mute the channel. They miss the failures that matter: checkout is not one operation, and a token that still validates on a health path can still be rejected on the write that follows. They stall rollout, because a program that must cover hundreds of operations never ships the first ten.
+
+Uptime-style checks make the problem worse. They answer whether a server responded, not whether the response still matches the description you publish. Contract-aware monitoring is the opposite bet: assert [status codes, content types, schemas, and success criteria](https://redocly.com/docs/realm/reunite/project/respect-monitoring) on the flows customers run, and accept that many operations will have no dedicated monitor until they earn one.
+
+Treat "every endpoint" as a backlog, not a launch criterion. The first slice should be small enough that a failure still has an owner.
+
+## Rank workflows, not isolated paths
+
+What is worth monitoring first is usually a workflow: authenticate, create a resource, read it back, maybe cancel. That is [sequences of operations rather than isolated paths](https://redocly.com/learn/arazzo/what-is-arazzo), which is what Arazzo is for. Ranking `POST /orders` without the token step and the subsequent GET will either false-alarm on auth setup or miss a break that only appears when steps share data.
+
+Ask AI to propose Arazzo-shaped flows, not a sorted table of paths. A good proposal names the job ("partner creates an order and fetches its status"), the operations in order, and what must be true after each step. A bad proposal is a restated tag list from the spec ("all `/billing/*` routes, high priority") with no success criteria and no evidence.
+
+If the model returns an operation that is not in the OpenAPI file, drop it. Invented paths are how ranking sessions turn into fiction. The spec is the allowlist; traffic and tickets are only weights on top of it.
+
+## Inputs AI needs to rank well
+
+Give the model four kinds of input, and withhold the rest.
+
+- OpenAPI, or a slice. A domain tags file or a single versioned description is enough. Whole-org dumps bury the signal and invite hallucinated servers.
+- Traffic or SLI hints. Even coarse notes help: "80% of 5xx last month were `POST /checkout`", "this partner integration is 30% of production writes." You do not need a perfect analytics export.
+- Support tickets and incident titles. Phrases like "example returns 404" or "pagination changed" often point at workflows docs already claim to cover.
+- Known revenue or partner paths. List the two or three jobs the business cannot pause, even if they are not the noisiest in logs.
+
+Do not paste secrets, full HAR dumps, or customer payloads. Summarize: method, path, status, and the field that surprised you. If tickets mention [holes in multi-step stories](https://redocly.com/learn/ai-for-docs/ai-find-gaps-documentation-coverage), include the job name ("create subscription after OAuth") rather than the entire guide.
+
+When the spec and the tickets disagree, say so in the prompt. "Tickets say clients send `Idempotency-Key` on POST /orders; the spec does not document that header" is a ranking input. It is also a docs or spec task, not a reason to monitor an undocumented operation until someone owns the contract.
+
+## A ranking prompt that produces a schedule
+
+Ask for a short ordered list you can paste into an Arazzo file, not a rewritten specification. Constrain the output: at most seven workflows, each with a name, steps tied to `operationId`s, success criteria, and a one-line reason that cites the inputs you provided.
+
+```text
+You are ranking API workflows to monitor first. Use only operations
+that appear in the attached OpenAPI. Do not invent paths, servers,
+or fields.
+
+Inputs: OpenAPI (attached). Traffic notes: {paste}. Support themes:
+{paste}. Business-critical jobs: {paste}.
+
+Return at most 7 workflows. For each:
+- workflowId (kebab-case)
+- steps: method + path or operationId, in order
+- success criteria (status and one schema or field check per step)
+- why it outranks the rest (cite a ticket theme or traffic hint)
+- what we are explicitly not covering yet
+
+If an input mentions a path that is not in the spec, list it under
+"needs spec decision" instead of a workflow.
+```
+
+Read the result like a test plan. Merge duplicates. Reject anything whose steps cannot be executed with the security schemes you use in staging. If the model ranks an internal debug route above checkout because a ticket mentioned it once, put that ticket on a docs list and keep checkout first.
+
+The output of this step is an ordered backlog, not a promise that the first item is the only risk. You are choosing where limited monitor budget goes this month.
+
+## Make the list operational in Respect
+
+A ranking that stays in a doc is a brainstorm. Put the first slice in an Arazzo file in the same repository as the OpenAPI description, then [run named workflows from the Arazzo file](https://redocly.com/docs/cli/commands/respect) with the Respect CLI `--workflow` option so you are not executing every flow while the list is still in draft.
+
+[Run the same Arazzo file in CI first](https://redocly.com/respect-cli). A workflow that cannot pass against staging with a non-production token is not ready for a hosted schedule. Fix the description, the environment, or the assertions before you page anyone.
+
+When the first two or three workflows are green in CI, [schedule those workflows on an interval](https://redocly.com/docs/realm/reunite/project/respect-monitoring/configure-respect-monitoring) in `redocly.yaml` (`schedule` for ongoing checks, `build` if you also want them on project builds). Start with a conservative interval on production and a tighter one on staging. Subscribe alerts only for the workflows in the first slice, so the channel stays tied to ranked risk.
+
+As the list changes, [archive workflows that are no longer in the first slice](https://redocly.com/docs/realm/reunite/project/respect-monitoring/manage-respect-monitoring) instead of leaving retired flows on the dashboard. Archived does not mean forgotten; it means the on-call view matches the current ranking.
+
+## Re-rank when the surface changes
+
+Re-run the ranking when you ship a new public job, after an incident that surprised you, and when a spec diff adds or removes operations in a tagged domain. The prompt can take the previous workflow list as an extra input: "keep these unless the new spec makes them impossible, and propose at most two additions."
+
+Do not freeze the first brainstorm for a year. Coverage that never moves is how exhaustive monitoring sneaks back in under a new name. When alerts start firing, [turn later alerts into doc or spec fixes](https://redocly.com/learn/ai-for-docs/ai-detect-drift-docs-live-api) rather than adding more paths in a panic. New monitors should still win a rank against the current slice.
+
+The habit is small and repeatable: rank a few workflows from the contract plus operational hints, schedule only those, and re-rank when the product changes. AI drafts the ordered list. Respect and CI make the list true.
+
+## FAQs
+
+### Why not monitor every operation in the OpenAPI file?
+
+Because exhaustive path lists create mute-able noise, miss multi-step failures, and delay the first useful schedule. Rank [sequences of operations rather than isolated paths](https://redocly.com/learn/arazzo/what-is-arazzo), then add operations only when they earn a place against that slice.
+
+### What inputs should we give an AI besides the spec?
+
+Traffic or SLI hints, support-ticket themes, and the two or three jobs the business cannot pause. Withhold secrets and full payload dumps. If tickets describe [holes in multi-step stories](https://redocly.com/learn/ai-for-docs/ai-find-gaps-documentation-coverage), pass the job name, not the entire guide.
+
+### How is a workflow different from an endpoint for monitoring?
+
+A workflow is an ordered job (authenticate, create, read) that shares data across calls. An endpoint monitor on a single GET can stay green while the POST that supplies its id has already broken.
+
+### How do we stop AI inventing undocumented paths?
+
+State that the OpenAPI file is an allowlist, and move anything the model invents into a "needs spec decision" list. Do not schedule a monitor for an undocumented operation until someone owns the contract.
+
+### When should CI workflows move to hosted monitoring?
+
+After it passes in CI against staging with non-production credentials. Then [schedule those workflows on an interval](https://redocly.com/docs/realm/reunite/project/respect-monitoring/configure-respect-monitoring) and subscribe alerts only for that first slice.
+
+### How often should we re-rank the monitor list?
+
+After a new public job, after an incident that surprised you, and when a spec diff changes a tagged domain. Re-ranking is how the list stays a decision instead of a frozen brainstorm.
+
+## How Redocly can help
+
+Respect is built for [scheduled monitoring of the paths that matter first](https://redocly.com/respect): Arazzo workflows on an interval, with alerts when those critical sequences stop matching the OpenAPI description, so a ranked list becomes coverage instead of a slide.

--- a/learn/ai-for-docs/sidebars.yaml
+++ b/learn/ai-for-docs/sidebars.yaml
@@ -24,6 +24,8 @@
   label: Use AI to find gaps in your documentation coverage
 - page: ai-detect-drift-docs-live-api.md
   label: Use AI to detect drift between your docs and your live API
+- page: ai-decide-which-api-endpoints-to-monitor-first.md
+  label: Use AI to decide which API endpoints to monitor first
 - page: ai-find-duplicate-underused-apis.md
   label: Use AI to find duplicate and underused APIs in your codebase
 - page: ai-build-searchable-api-catalog.md


### PR DESCRIPTION
## Summary
- Adds `learn/ai-for-docs/ai-decide-which-api-endpoints-to-monitor-first.md` from the Calendar draft.
- Updates `learn/ai-for-docs/sidebars.yaml` with the new page entry.

## Test plan
- [ ] Preview the page locally via `npm start`
- [ ] Confirm sidebar label and SEO front matter
- [ ] Spot-check internal links and How Redocly can help