### PR TITLE
Add: API monitoring best practices

### DIFF
--- a/learn/ai-for-docs/api-monitoring-best-practices.md
+++ b/learn/ai-for-docs/api-monitoring-best-practices.md
@@ -8,100 +8,74 @@ seo:
 
 ## Key takeaways
 
-- Treat the OpenAPI description as the contract the monitor must enforce, not as optional documentation.
-- Cover critical Arazzo workflows first; do not equate path count with safety.
-- Run the same workflows in CI and on a hosted schedule, with alerts that name an owner.
-- Keep Arazzo, OpenAPI, and docs in one git review so monitors cannot silently rot.
+- Uptime and latency checks confirm that a server is responding, not that its responses still match the OpenAPI contract, so a 200 OK can hide a dropped field, a changed type, or an undocumented status code.
+- Best-practice monitoring tests live API behavior against the OpenAPI and Arazzo descriptions on a schedule, using tools like Respect to autogenerate tests instead of hand-writing assertions.
+- Start with the critical workflows that matter most to the business, then automate checks and route alerts through Slack or email so failures reach the right people fast.
+- Multi-step workflows need their own tests, since a single-endpoint check can miss failures that only appear when data flows from one call to the next.
+- A monitoring failure is only useful if it turns into a fix. Teams should trace each alert back to a spec, docs, or code change and merge it through their normal review process.
 
-API monitoring is easy to confuse with uptime. A probe that receives HTTP 200 looks healthy, and [dashboards that stay green while a required field disappears](https://redocly.com/blog/api-contract-testing-arazzo) are a common incident story. Clients do not consume "the server responded." They consume the contract you published: status codes, headers, and body shape.
+Most teams that ship an API also set up some form of monitoring, and for years that has meant checking whether an endpoint returns a 200 status code within an acceptable response time. Uptime dashboards turn green, latency graphs stay flat, and everyone assumes the API is healthy. But an API can be up, fast, and still broken in ways that uptime checks never see: a field silently dropped from a response, a type that changed from a string to a number, or an undocumented status code that a client doesn't know how to handle. The dashboard stays green while the contract between the API and its consumers falls apart, and the first people to notice are often the customers filing support tickets, not the team watching the monitor.
 
-Best practice is to treat the OpenAPI description as that contract, watch a small set of real user workflows, assert what the spec already promised, and keep those monitors in the same git project as the spec and the docs. The rest of this article is that loop, not a catalog of ping products.
+This is the gap that best-practice API monitoring is meant to close. Rather than asking only whether the server is responding, it asks whether the server is responding the way the OpenAPI description says it will. Reading through the [benefits and challenges of contract testing](https://redocly.com/learn/testing/contract-testing-101) is a useful starting point for docs orgs and platform teams trying to explain why uptime alone doesn't prove that an API works the way it's documented.
 
-## Monitor the contract, not only uptime
+## Why traditional uptime monitoring isn't enough
 
-Uptime answers a narrow question: did this URL respond in time? Contract monitoring asks whether the response still matches the description customers and generated SDKs rely on. [A response-format change that client tests never saw](https://redocly.com/learn/testing/contract-testing-101) can ship behind a 200 and a green availability tile.
+Uptime and latency checks answer a narrow question well: is something listening on the other end. They don't ask whether the response body matches the schema a team published, whether a required field is still present, or whether an error case returns the status code the documentation promises. Because these checks pass as long as a server responds at all, they can mask exactly the kind of change most likely to break an integration. Industry writing on this problem has started calling out the pattern directly, noting how [monitoring dashboards stay green while the API breaks](https://redocly.com/blog/api-contract-testing-arazzo) underneath, because nothing in a simple ping check was ever designed to catch a contract violation. The cost of that blind spot shows up
+downstream, in [unexpected status codes, incorrect content types, and schema mismatches](https://redocly.com/blog/respect) that surface in a customer's integration long before they show up in an internal alert.
 
-That does not make pings useless. Keep them for "is the load balancer up?" Put contract checks on the paths where a wrong body is a customer-visible break. Respect's hosted checks, for example, compare live responses to [status, schema, content type, and success criteria](https://redocly.com/docs/realm/reunite/project/respect-monitoring) from the OpenAPI description linked in an Arazzo workflow. [Checks that go past availability](https://redocly.com/blog/respect) are the difference between "the API is up" and "the API still keeps its promise."
+## Monitor against your OpenAPI contract, not just status codes
 
-If you only have budget for one kind of monitor this quarter, put it on the contract for the jobs you cannot pause. Availability without schema checks will not catch [a schema mismatch that only showed up against the live server](https://redocly.com/learn/arazzo/practical-example-series/api-contract-testing-01).
+A more reliable approach treats the OpenAPI description as the thing being tested, rather than documentation that simply sits next to the code. Respect, Redocly's monitoring product, works this way: it [checks your API responses match what the OpenAPI description says](https://redocly.com/docs/respect), comparing live behavior against the schemas, required fields, and status codes already defined in the spec. Because the tests come from the spec itself, teams don't have to hand-write assertions for every field. Respect [autogenerates tests from OpenAPI to get started quickly](https://redocly.com/docs/respect/what-is-respect), which lowers the barrier for docs owners and platform engineers who want contract-level coverage without building a testing framework from
+scratch. Getting started only takes a small first step: you can [write your first test description](https://redocly.com/docs/respect/get-started) against a real or demo API and see, right away, what contract-based monitoring surfaces that a status-code check would have missed.
 
-## Prefer workflows over exhaustive path lists
+## Prioritize critical workflows before trying to cover everything
 
-Most customer jobs are not a single operation. Login, create, and read-back share tokens and ids. A per-path monitor on `GET /orders/{id}` can stay green while `POST /orders` stops returning the id the GET needs, or while the token step starts issuing a different header.
+Trying to monitor every endpoint on day one is a common instinct, and it usually backfires. Large APIs can have hundreds of operations, and treating them all as equally urgent tends to produce noisy alerts that teams eventually learn to ignore. A steadier approach starts with the handful of workflows that matter most to the business, such as authentication, checkout, or account creation, whatever the equivalent "if this breaks, support gets flooded" path looks like for a given product. Reviewing [common monitoring use cases](https://redocly.com/docs/respect/use-cases) can help teams see how others have scoped this first pass before expanding coverage. Once the critical paths are solid, monitoring can grow outward to secondary endpoints, rather than starting broad and
+thin.
 
-[Describe the sequence of calls, not only each operation](https://redocly.com/learn/arazzo/what-is-arazzo). Arazzo is the OpenAPI Initiative format for that choreography. Monitoring the workflow tests data flow, not only isolated status codes.
+## Automate checks on a schedule and alert through the tools your team already uses
 
-Do not aim for "every path in the spec has a check." Exhaustive lists create mute-able noise and delay the first useful schedule. Start with the two or three jobs that represent revenue, partners, or the happy path in your getting-started guide. Expand when an incident shows a gap, not when a completeness score looks low.
+Monitoring that depends on someone remembering to run it manually tends to lapse. A more durable pattern is to schedule checks so they run continuously, and to route failures into the channels a team already watches, rather than a dashboard nobody checks between incidents. Inside Reunite, teams can [schedule automated checks and configure alerts](https://redocly.com/docs/realm/reunite/project/respect-monitoring/configure-respect-monitoring) so that contract failures land in Slack, email, or wherever on-call already lives. Speed matters here, because an alert that arrives minutes after a contract violation is far more useful than a report generated once a week: it gives the team a chance to fix the problem before a customer opens a ticket about it.
 
-Health endpoints belong in availability monitoring. They rarely belong in the first contract-workflow set, because they are designed not to exercise the product.
+## Catch breaking changes and drift before customers do
 
-## Assert what the spec already promised
+Specs and implementations tend to drift apart over time, often without any single change feeling significant enough to flag. A field gets renamed in code but not in the spec, or a new required parameter ships without an update to the description. Left unchecked, this drift accumulates until the documentation and the API describe two different systems. Scheduled contract tests are one of the more effective ways to [catch drift between what your OpenAPI description says and what your API does](https://redocly.com/blog/catch-api-drift) before it reaches a customer's integration. Related tooling that pairs AI with monitoring can also help teams [detect drift between your docs and your live API](https://redocly.com/learn/ai-for-docs/ai-detect-drift-docs-live-api), turning a
+raw diff into a plain-language summary of what changed.
 
-Weak assertions are how silent failures hide. "Status is 2xx" will not notice a required field going missing. "Body is JSON" will not notice an extra property you never meant to leak.
+## Test multi-step workflows, not just single endpoints
 
-For each step, [spell out what success means for each step](https://redocly.com/learn/arazzo/success-criteria-and-failure-handling) in addition to the automatic OpenAPI checks. Typical baseline:
+Real usage of most APIs isn't a single call made in isolation. A customer logs in, then fetches a resource, then updates it, then confirms the update went through. Testing each endpoint independently can miss failures that only appear when data flows from one step to the next, such as a token that isn't accepted on the follow-up call or a resource ID that doesn't round-trip cleanly. This is where Arazzo, the specification for describing multi-step API workflows, becomes useful alongside Respect: teams can [test multi-step API workflows](https://redocly.com/learn/arazzo/testing-arazzo-workflows) and [define success criteria for each step](https://redocly.com/learn/arazzo/success-criteria-and-failure-handling), so a failure at step three gets reported clearly rather than
+buried in a generic error. For teams starting from an existing OpenAPI description, it's possible to [auto-generate a starting workflow from an OpenAPI description](https://redocly.com/docs/respect/commands/generate-arazzo) rather than authoring the whole sequence by hand.
 
-- Status matches a documented response
-- `Content-Type` matches the documented media type
-- Body validates against the documented schema
-- One business check the schema cannot see by itself (for example, the create response `id` is present and reused on the next step)
+## Close the loop by turning monitoring failures into documentation and spec fixes
 
-If the spec is wrong, fix the spec. Do not weaken the monitor to match a bug you intend to keep. If production is right and the spec is stale, that is a documentation and description change, not a reason to delete the schema check.
+A monitoring failure that never becomes a fix is just noise with extra steps. The most useful monitoring setups treat each alert as the start of a small, well-scoped task: confirm whether the bug lives in production, the spec, or the docs, then update whichever one is wrong. Because Respect Monitoring runs against a Git-connected project, a failure can turn into a concrete change quickly. A writer or engineer can [open a pull request with the fix](https://redocly.com/docs/realm/reunite/project/pull-request/open-pull-request), whether that means correcting a schema, updating a description, or patching the API itself, and get it reviewed through the same workflow the team already uses for other docs and spec changes. Over time, this habit of closing the loop is what
+keeps the OpenAPI description trustworthy enough to keep testing against.
 
-Revisit assertions when you add required fields or change error shapes. A success criterion that still looks for a removed property is workflow rot, and it trains the team to ignore failures.
+## Conclusion
 
-## Schedule by risk, then alert with a next step
-
-Run monitors where failure has an owner. [Run on a schedule or on every project build](https://redocly.com/docs/realm/reunite/project/respect-monitoring/configure-respect-monitoring): `build` catches description and environment breaks before a deploy is considered done; `schedule` catches production drift after merge. Intervals should match blast radius. A checkout workflow might run every few minutes in production; a rarely used admin export can wait hours.
-
-Alerts need a next step, not only a red tile. [Notify Slack when a workflow fails, and archive the ones you retired](https://redocly.com/docs/realm/reunite/project/respect-monitoring/manage-respect-monitoring). Subscribe per workflow so a noisy experimental flow cannot drown the critical one. Include enough in the alert (workflow, step, check type) that the person who gets it can classify production versus description versus assertion without hunting for context.
-
-If you set SLA or uptime thresholds, treat them as a second signal. Schema failures and SLO breaches are different conversations. Do not page the docs team for a 500 that is a service outage, and do not page only SRE for a 200 whose body no longer matches the spec.
-
-## Run the same checks in CI and in production
-
-The Arazzo file should not be a production-only artifact. [The same Arazzo file in CI](https://redocly.com/respect-cli) is how you find a broken workflow before it pages anyone. Developers can run Respect CLI locally against a sandbox; the pipeline can run named workflows on pull requests that touch OpenAPI or Arazzo files.
-
-Hosted schedules then reuse that file. If CI and production monitors diverge, you will debug "works in GitHub Actions" failures that are really environment or secret differences. Keep server URLs and inputs explicit. Staging should be allowed to fail a workflow that production has not shipped yet, without muting the production job.
-
-When you need to find routes nobody wrote a workflow for, [compare recorded traffic to the OpenAPI description](https://redocly.com/blog/catch-api-drift) with `proxy` and `drift`. That practice complements scheduled workflows. It does not replace them. Traffic capture is how you discover undocumented behavior; Arazzo is how you keep watching the jobs you already care about.
-
-## Keep monitors next to the spec
-
-Monitors rot when they live in a separate click-ops project from the OpenAPI file. Put Arazzo descriptions in the same repository (or the same Reunite project) as the spec and the docs, and review them together. A PR that adds a required field should update the schema, the example, and the workflow assertion in one diff.
-
-Archive retired workflows instead of leaving them red forever. A dashboard full of abandoned jobs is how teams learn that red is normal.
-
-When the description, the docs, and the monitor disagree, decide which of the three is the source of truth for that change, then update the other two. The OpenAPI file should win for generated reference. The monitor should win as the test that production still matches that file. Prose guides should follow, not invent a fourth contract.
-
-That is the practice in one line: monitor the contract on a few real workflows, on a schedule the team will honor, in git next to the spec. Uptime remains a separate, smaller question.
+Uptime monitoring will always have a place, but it answers a smaller question than most teams assume it does. The more useful question, and the one that protects customers from breakage that's hard to spot, is whether the API still behaves the way its OpenAPI and Arazzo descriptions say it should. That means testing the contract itself, focusing first on the workflows that matter most, scheduling checks so nothing depends on memory, treating drift as something to catch early rather than explain later, and following every failure through to a real fix in the spec or the docs. None of this replaces careful API design or good documentation, but it does keep the two honest with each other after launch, which is usually where the real risk lives.
 
 ## FAQs
 
-### How is API monitoring different from uptime monitoring?
+**Is uptime monitoring the same as API monitoring?**
+No. Uptime monitoring only confirms that a server responds within an expected time, while API monitoring in the best-practice sense also checks whether the response body, status codes, and types still match what the OpenAPI description promises. An API can pass every uptime check and still be broken in ways that only show up when responses are validated against the contract.
 
-Uptime asks whether a URL responded in time. API monitoring in this sense asks whether the response still matches the published contract. [Dashboards that stay green while a required field disappears](https://redocly.com/blog/api-contract-testing-arazzo) are an uptime success and a contract failure.
+**What does it mean to monitor an API against its contract?**
+It means testing live responses against the schemas, required fields, and status codes already defined in the OpenAPI description, rather than writing separate assertions by hand. Respect works this way: it [checks your API responses match what the OpenAPI description says](https://redocly.com/docs/respect) and reports any mismatches.
 
-### How many workflows should we start with?
+**How do I decide which endpoints to monitor first?**
+Start with the workflows that would cause the most damage if they broke, such as authentication or checkout, rather than trying to cover every endpoint at once. Reviewing [common monitoring use cases](https://redocly.com/docs/respect/use-cases) can help you scope this first pass before expanding coverage to secondary endpoints.
 
-Two or three jobs that represent revenue, partners, or the getting-started happy path. Expand when an incident shows a gap. Do not wait until every path has a check.
+**What is API drift, and how is it caught?**
+Drift is the gradual gap that opens up between an OpenAPI description and the API's actual behavior, often from small changes that never get reflected in the spec. Scheduled contract tests help teams [catch drift between what your OpenAPI description says and what your API does](https://redocly.com/blog/catch-api-drift) before it reaches a customer's integration.
 
-### What should a monitor assert besides HTTP 200?
+**Can monitoring cover multi-step workflows, not just single requests?**
+Yes. Using the Arazzo specification alongside Respect, teams can [test multi-step API workflows](https://redocly.com/learn/arazzo/testing-arazzo-workflows) so that failures which only appear when data flows from one call to the next, like a token that isn't accepted on a follow-up request, get caught and reported clearly.
 
-At least documented status, content type, and schema, plus [what success means for each step](https://redocly.com/learn/arazzo/success-criteria-and-failure-handling) when the schema cannot see the business rule (for example, reuse of a created `id`).
-
-### Should monitors run in CI, on a schedule, or both?
-
-Both. [The same Arazzo file in CI](https://redocly.com/respect-cli) catches breaks before merge. [Run on a schedule or on every project build](https://redocly.com/docs/realm/reunite/project/respect-monitoring/configure-respect-monitoring) to catch production drift after merge.
-
-### Where should Arazzo files live relative to the OpenAPI description?
-
-In the same git project (or Reunite project) as the spec and the docs, so a required-field change updates schema, example, and assertion in one review.
-
-### How do we stop alert noise without dropping coverage?
-
-Subscribe per workflow, archive retired flows, and keep health pings out of the first contract-workflow set. [Notify Slack when a workflow fails, and archive the ones you retired](https://redocly.com/docs/realm/reunite/project/respect-monitoring/manage-respect-monitoring) so the channel matches the jobs you still mean to honor.
+**What should happen after a monitoring check fails?**
+A failure should lead to a concrete fix, not just an acknowledged alert. Once the cause is confirmed, whether it's a bug, a spec error, or outdated docs, a writer or engineer can [open a pull request with the fix](https://redocly.com/docs/realm/reunite/project/pull-request/open-pull-request) and route it through the team's normal review process.
 
 ## How Redocly can help
 
-Respect provides [scheduled contract checks with alerts when behavior diverges](https://redocly.com/respect) from the OpenAPI description you already maintain, so the practices above (workflows, assertions, CI plus schedule) sit on one Arazzo file instead of a pile of unrelated pings.
+The thesis here comes down to trust: an API's documentation is only as reliable as the checks that keep it honest against what the API actually does in production. Respect offers [continuous API monitoring powered by OpenAPI Arazzo workflows](https://redocly.com/respect), so teams can move from watching a dashboard stay green to knowing, on a schedule, that real responses still match the contract they published.

--- a/learn/ai-for-docs/api-monitoring-best-practices.md
+++ b/learn/ai-for-docs/api-monitoring-best-practices.md
@@ -1,0 +1,107 @@
+---
+seo:
+ title: API monitoring best practices
+ description: Monitor the OpenAPI contract on a few Arazzo workflows in CI and on a schedule, with alerts and git next to the spec, instead of uptime-only pings.
+---
+
+# API monitoring best practices
+
+## Key takeaways
+
+- Treat the OpenAPI description as the contract the monitor must enforce, not as optional documentation.
+- Cover critical Arazzo workflows first; do not equate path count with safety.
+- Run the same workflows in CI and on a hosted schedule, with alerts that name an owner.
+- Keep Arazzo, OpenAPI, and docs in one git review so monitors cannot silently rot.
+
+API monitoring is easy to confuse with uptime. A probe that receives HTTP 200 looks healthy, and [dashboards that stay green while a required field disappears](https://redocly.com/blog/api-contract-testing-arazzo) are a common incident story. Clients do not consume "the server responded." They consume the contract you published: status codes, headers, and body shape.
+
+Best practice is to treat the OpenAPI description as that contract, watch a small set of real user workflows, assert what the spec already promised, and keep those monitors in the same git project as the spec and the docs. The rest of this article is that loop, not a catalog of ping products.
+
+## Monitor the contract, not only uptime
+
+Uptime answers a narrow question: did this URL respond in time? Contract monitoring asks whether the response still matches the description customers and generated SDKs rely on. [A response-format change that client tests never saw](https://redocly.com/learn/testing/contract-testing-101) can ship behind a 200 and a green availability tile.
+
+That does not make pings useless. Keep them for "is the load balancer up?" Put contract checks on the paths where a wrong body is a customer-visible break. Respect's hosted checks, for example, compare live responses to [status, schema, content type, and success criteria](https://redocly.com/docs/realm/reunite/project/respect-monitoring) from the OpenAPI description linked in an Arazzo workflow. [Checks that go past availability](https://redocly.com/blog/respect) are the difference between "the API is up" and "the API still keeps its promise."
+
+If you only have budget for one kind of monitor this quarter, put it on the contract for the jobs you cannot pause. Availability without schema checks will not catch [a schema mismatch that only showed up against the live server](https://redocly.com/learn/arazzo/practical-example-series/api-contract-testing-01).
+
+## Prefer workflows over exhaustive path lists
+
+Most customer jobs are not a single operation. Login, create, and read-back share tokens and ids. A per-path monitor on `GET /orders/{id}` can stay green while `POST /orders` stops returning the id the GET needs, or while the token step starts issuing a different header.
+
+[Describe the sequence of calls, not only each operation](https://redocly.com/learn/arazzo/what-is-arazzo). Arazzo is the OpenAPI Initiative format for that choreography. Monitoring the workflow tests data flow, not only isolated status codes.
+
+Do not aim for "every path in the spec has a check." Exhaustive lists create mute-able noise and delay the first useful schedule. Start with the two or three jobs that represent revenue, partners, or the happy path in your getting-started guide. Expand when an incident shows a gap, not when a completeness score looks low.
+
+Health endpoints belong in availability monitoring. They rarely belong in the first contract-workflow set, because they are designed not to exercise the product.
+
+## Assert what the spec already promised
+
+Weak assertions are how silent failures hide. "Status is 2xx" will not notice a required field going missing. "Body is JSON" will not notice an extra property you never meant to leak.
+
+For each step, [spell out what success means for each step](https://redocly.com/learn/arazzo/success-criteria-and-failure-handling) in addition to the automatic OpenAPI checks. Typical baseline:
+
+- Status matches a documented response
+- `Content-Type` matches the documented media type
+- Body validates against the documented schema
+- One business check the schema cannot see by itself (for example, the create response `id` is present and reused on the next step)
+
+If the spec is wrong, fix the spec. Do not weaken the monitor to match a bug you intend to keep. If production is right and the spec is stale, that is a documentation and description change, not a reason to delete the schema check.
+
+Revisit assertions when you add required fields or change error shapes. A success criterion that still looks for a removed property is workflow rot, and it trains the team to ignore failures.
+
+## Schedule by risk, then alert with a next step
+
+Run monitors where failure has an owner. [Run on a schedule or on every project build](https://redocly.com/docs/realm/reunite/project/respect-monitoring/configure-respect-monitoring): `build` catches description and environment breaks before a deploy is considered done; `schedule` catches production drift after merge. Intervals should match blast radius. A checkout workflow might run every few minutes in production; a rarely used admin export can wait hours.
+
+Alerts need a next step, not only a red tile. [Notify Slack when a workflow fails, and archive the ones you retired](https://redocly.com/docs/realm/reunite/project/respect-monitoring/manage-respect-monitoring). Subscribe per workflow so a noisy experimental flow cannot drown the critical one. Include enough in the alert (workflow, step, check type) that the person who gets it can classify production versus description versus assertion without hunting for context.
+
+If you set SLA or uptime thresholds, treat them as a second signal. Schema failures and SLO breaches are different conversations. Do not page the docs team for a 500 that is a service outage, and do not page only SRE for a 200 whose body no longer matches the spec.
+
+## Run the same checks in CI and in production
+
+The Arazzo file should not be a production-only artifact. [The same Arazzo file in CI](https://redocly.com/respect-cli) is how you find a broken workflow before it pages anyone. Developers can run Respect CLI locally against a sandbox; the pipeline can run named workflows on pull requests that touch OpenAPI or Arazzo files.
+
+Hosted schedules then reuse that file. If CI and production monitors diverge, you will debug "works in GitHub Actions" failures that are really environment or secret differences. Keep server URLs and inputs explicit. Staging should be allowed to fail a workflow that production has not shipped yet, without muting the production job.
+
+When you need to find routes nobody wrote a workflow for, [compare recorded traffic to the OpenAPI description](https://redocly.com/blog/catch-api-drift) with `proxy` and `drift`. That practice complements scheduled workflows. It does not replace them. Traffic capture is how you discover undocumented behavior; Arazzo is how you keep watching the jobs you already care about.
+
+## Keep monitors next to the spec
+
+Monitors rot when they live in a separate click-ops project from the OpenAPI file. Put Arazzo descriptions in the same repository (or the same Reunite project) as the spec and the docs, and review them together. A PR that adds a required field should update the schema, the example, and the workflow assertion in one diff.
+
+Archive retired workflows instead of leaving them red forever. A dashboard full of abandoned jobs is how teams learn that red is normal.
+
+When the description, the docs, and the monitor disagree, decide which of the three is the source of truth for that change, then update the other two. The OpenAPI file should win for generated reference. The monitor should win as the test that production still matches that file. Prose guides should follow, not invent a fourth contract.
+
+That is the practice in one line: monitor the contract on a few real workflows, on a schedule the team will honor, in git next to the spec. Uptime remains a separate, smaller question.
+
+## FAQs
+
+### How is API monitoring different from uptime monitoring?
+
+Uptime asks whether a URL responded in time. API monitoring in this sense asks whether the response still matches the published contract. [Dashboards that stay green while a required field disappears](https://redocly.com/blog/api-contract-testing-arazzo) are an uptime success and a contract failure.
+
+### How many workflows should we start with?
+
+Two or three jobs that represent revenue, partners, or the getting-started happy path. Expand when an incident shows a gap. Do not wait until every path has a check.
+
+### What should a monitor assert besides HTTP 200?
+
+At least documented status, content type, and schema, plus [what success means for each step](https://redocly.com/learn/arazzo/success-criteria-and-failure-handling) when the schema cannot see the business rule (for example, reuse of a created `id`).
+
+### Should monitors run in CI, on a schedule, or both?
+
+Both. [The same Arazzo file in CI](https://redocly.com/respect-cli) catches breaks before merge. [Run on a schedule or on every project build](https://redocly.com/docs/realm/reunite/project/respect-monitoring/configure-respect-monitoring) to catch production drift after merge.
+
+### Where should Arazzo files live relative to the OpenAPI description?
+
+In the same git project (or Reunite project) as the spec and the docs, so a required-field change updates schema, example, and assertion in one review.
+
+### How do we stop alert noise without dropping coverage?
+
+Subscribe per workflow, archive retired flows, and keep health pings out of the first contract-workflow set. [Notify Slack when a workflow fails, and archive the ones you retired](https://redocly.com/docs/realm/reunite/project/respect-monitoring/manage-respect-monitoring) so the channel matches the jobs you still mean to honor.
+
+## How Redocly can help
+
+Respect provides [scheduled contract checks with alerts when behavior diverges](https://redocly.com/respect) from the OpenAPI description you already maintain, so the practices above (workflows, assertions, CI plus schedule) sit on one Arazzo file instead of a pile of unrelated pings.

--- a/learn/ai-for-docs/sidebars.yaml
+++ b/learn/ai-for-docs/sidebars.yaml
@@ -24,6 +24,8 @@
   label: Use AI to find gaps in your documentation coverage
 - page: ai-detect-drift-docs-live-api.md
   label: Use AI to detect drift between your docs and your live API
+- page: api-monitoring-best-practices.md
+  label: API monitoring best practices
 - page: ai-find-duplicate-underused-apis.md
   label: Use AI to find duplicate and underused APIs in your codebase
 - page: ai-build-searchable-api-catalog.md


### PR DESCRIPTION
## Summary
- Adds `learn/ai-for-docs/api-monitoring-best-practices.md` from the Calendar draft.
- Updates `learn/ai-for-docs/sidebars.yaml` with the new page entry.

## Test plan
- [ ] Preview the page locally via `npm start`
- [ ] Confirm sidebar label and SEO front matter
- [ ] Spot-check internal links and How Redocly can help