### PR TITLE
chore(deps): update js-yaml in markdownlint-cli2 dependency [security]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7437,19 +7437,6 @@
         "markdownlint-cli2": ">=0.0.4"
       }
     },
-    "node_modules/markdownlint-cli2/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/marked": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
     "markdown-it@<14.2.0": "14.3.0",
     "dompurify@<3.4.13": "3.4.13",
     "@redocly/realm": "0.137.0-next.1",
-    "@redocly/theme": "0.69.0-next.1"
+    "@redocly/theme": "0.69.0-next.1",
+    "markdownlint-cli2": {
+      "js-yaml": "^4.3.1"
+    }
   }
 }


### PR DESCRIPTION
## What/Why/How?

Fixed js-yaml Dependabot alerts (#172, #176, #186 — CVE-2026-59869, CVE-2026-53550, GHSA-5p4m-2wfm-xmqj):

- `markdownlint-cli2` exact-pins js-yaml `4.1.1`; added a scoped override `"markdownlint-cli2": { "js-yaml": "^4.3.1" }` so it resolves `4.3.1`.
- Bumping markdownlint-cli2 itself (0.20 → 0.23) was rejected: it changes lint rules drastically (226 → 11333 errors). The override keeps lint behavior identical.
- Remove the override when markdownlint-cli2 ships js-yaml >= 4.3.1 (its 0.23+ line ships 5.x).

## Reference

https://github.com/Redocly/website/security/dependabot/176

## Testing

- `npm run lint:markdown` reports exactly the same 226 pre-existing errors as main — no behavior change.
- Lockfile now resolves only js-yaml 4.3.1 / 5.3.0.

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [x] Tested
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
