### PR TITLE
fix(realm): allow the AI assistant CDN and the hydration script in the CSP

### DIFF
--- a/redocly.yaml
+++ b/redocly.yaml
@@ -205,6 +205,7 @@ responseHeaders:
           https://js.hs-analytics.net
           https://js.hs-banner.com
           https://cdn.jsdelivr.net
+          https://cdn.redocly.com
           'sha256-M28mypAFwwpIwIF9e1/A6867PQiwVvOrdqFSTFSa8/U=' 
           'sha256-Ed6Lei7deBSXT1iYYw0V36YZXaA4v7OsRknNjmNl/9c='
           'sha256-uDN+KkW4ljf+D4DbsWP5KpxyfG/7h+LNmZxMzbz/+1E='
@@ -220,7 +221,8 @@ responseHeaders:
           'sha256-+Ozb/ItuZAdaQgJd2RebN2rKWj1XkBuXVaV6/lT4Juo='
           'sha256-9qgU5FDrauEgF+e1iJWvsh46OwsIkNOLjkXggr/02jk='
           'sha256-v7ddZtWCUr5oF3kgrlEot4fG861CKDXUt0aTaNaIk6Q='
-          'sha256-+t5Z3fJi7uJxARWEzFEVaSRgtaAn0r97XkxpJNbQiK0=';
+          'sha256-+t5Z3fJi7uJxARWEzFEVaSRgtaAn0r97XkxpJNbQiK0='
+          'sha256-gOx3nRh8znDQR7T1VkI+fFXDgsNzf5enQqdi7NP11Vk=';
         object-src 'none'; 
         base-uri 'self'; 
         connect-src 


### PR DESCRIPTION
## What/Why/How?

Two `script-src` additions to the global CSP.

- **`https://cdn.redocly.com`** - The AI assistant playground on [the web component docs page](https://redocly.com/docs/realm/ai-assistant-web-component/ai-assistant-web-component) loads the widget bundle from this host. A `srcdoc` iframe inherits the parent page's CSP, so the bundle is blocked and the playground currently renders nothing on prod: `window.RedoclyAssistant` is `undefined` and `<redocly-ai-assistant>` never upgrades.
- **`sha256-gOx3nRh8znDQR7T1VkI+fFXDgsNzf5enQqdi7NP11Vk=`** - The react-router `window.__staticRouterHydrationData` script. This is unrelated to the playground: it is blocked on every page of the site, and is the likely source of the `Minified React error #418` hydration warning in the console.

The `/editor` block is untouched. The playground is not on that route.

I added the host to the global `'**'` block rather than a page-scoped one. A more specific pattern replaces the global CSP instead of merging with it, so a scoped block means copying all 40 lines and keeping them in sync. The `/editor` block already shows that drift: it is missing the HubSpot and Clarity hosts and about ten hashes the global block has gained since.

## Reference

Follow-up to Redocly/redocly#26113, which shipped the playground.

## Testing

Served the exact `srcdoc` document from prod behind this branch's CSP on a local server, then loaded it in a browser:

| | before | after |
|---|---|---|
| `typeof RedoclyAssistant` | `undefined` | `object` |
| custom element upgraded | no | yes |
| shadow root attached | no | yes |

Verified `redocly.yaml` still parses and all ten CSP directives survive the edit.

One violation remains after this change, by design: the playground's preview document also runs a small inline script, and its hash is deliberately **not** added here. Hash-allowlisting it would mean a CSP change in this repo every time that script's whitespace changes. It will be removed from the docs source instead, in Redocly/redocly. Its only effect is the preview panel's desktop width, so the playground is usable without it.

## Screenshots (optional)

Before: (errors and nothing renders):
<img width="1250" height="862" alt="image" src="https://github.com/user-attachments/assets/3252966d-15e4-4f1a-8d96-cd27d096e9db" />

After: 
<img width="1507" height="951" alt="image" src="https://github.com/user-attachments/assets/b562c00d-bd9c-41fb-90d2-036555dbdbb1" />


## Check yourself

- [x] Code is linted
- [x] Tested
- [ ] All new/updated code is covered with tests

No test layer covers this repo's response headers.

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

`cdn.redocly.com` is a Redocly-owned CDN. The added hash pins one exact inline script, which is strictly narrower than a nonce or `'unsafe-inline'`. No directive is loosened and no keyword source is added.
